### PR TITLE
Make temporal options more flexible

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ val documentationScalaVersion = scala213
 
 ThisBuild / scalaVersion           := scala213
 ThisBuild / organization           := "dev.vhonta"
-ThisBuild / version                := "0.1.0-RC4"
+ThisBuild / version                := "0.1.0-RC5"
 ThisBuild / versionScheme          := Some("early-semver")
 ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
 ThisBuild / sonatypeRepository     := "https://s01.oss.sonatype.org/service/local"

--- a/core/src/main/scala/zio/temporal/ZAwaitTerminationOptions.scala
+++ b/core/src/main/scala/zio/temporal/ZAwaitTerminationOptions.scala
@@ -4,15 +4,13 @@ import zio._
 
 /** Represents options for [[zio.temporal.workflow.ZWorkflowServiceStubs.awaitTermination]] method
   */
-class ZAwaitTerminationOptions private[zio] (val pollTimeout: Duration, val pollDelay: Duration) {
+case class ZAwaitTerminationOptions private[zio] (pollTimeout: Duration, pollDelay: Duration) {
 
   def withPollTimeout(timeout: Duration): ZAwaitTerminationOptions =
     new ZAwaitTerminationOptions(timeout, pollDelay)
 
   def withPollDelay(delay: Duration): ZAwaitTerminationOptions =
     new ZAwaitTerminationOptions(pollTimeout, delay)
-
-  override def toString: String = s"ZAwaitTerminationOptions(pollTimeout=$pollTimeout, pollDelay=$pollDelay)"
 }
 
 object ZAwaitTerminationOptions {

--- a/core/src/main/scala/zio/temporal/activity/ZActivityStubBuilder.scala
+++ b/core/src/main/scala/zio/temporal/activity/ZActivityStubBuilder.scala
@@ -88,6 +88,16 @@ class ZActivityStubBuilder[A] private[zio] (
   def withCancellationType(cancellationType: ActivityCancellationType): ZActivityStubBuilder[A] =
     copy(_.setCancellationType(cancellationType))
 
+  /** Allows to specify options directly on the java SDK's [[ActivityOptions]]. Use it in case an appropriate `withXXX`
+    * method is missing
+    *
+    * @note
+    *   the options specified via this method take precedence over those specified via other methods.
+    */
+  def transformJavaOptions(
+    f: ActivityOptions.Builder => ActivityOptions.Builder
+  ): ZActivityStubBuilder[A] = copy(f)
+
   /** Builds ActivityStub
     * @return
     *   activity stub

--- a/core/src/main/scala/zio/temporal/worker/ZWorkerFactoryOptions.scala
+++ b/core/src/main/scala/zio/temporal/worker/ZWorkerFactoryOptions.scala
@@ -9,40 +9,32 @@ import zio._
   * @see
   *   [[WorkerFactoryOptions]]
   */
-class ZWorkerFactoryOptions private (
+case class ZWorkerFactoryOptions private[zio] (
   workflowHostLocalTaskQueueScheduleToStartTimeout: Option[Duration],
   workflowCacheSize:                                Option[Int],
   maxWorkflowThreadCount:                           Option[Int],
   workerInterceptors:                               List[WorkerInterceptor],
   enableLoggingInReplay:                            Option[Boolean],
-  workflowHostLocalPollThreadCount:                 Option[Int]) {
-
-  override def toString: String =
-    s"ZWorkerFactoryOptions(" +
-      s"workflowHostLocalTaskQueueScheduleToStartTimeout=$workflowHostLocalTaskQueueScheduleToStartTimeout, " +
-      s"workflowCacheSize=$workflowCacheSize, " +
-      s"maxWorkflowThreadCount=$maxWorkflowThreadCount, " +
-      s"workerInterceptors=$workerInterceptors, " +
-      s"enableLoggingInReplay=$enableLoggingInReplay, " +
-      s"workflowHostLocalPollThreadCount=$workflowHostLocalPollThreadCount)"
+  workflowHostLocalPollThreadCount:                 Option[Int],
+  private val javaOptionsCustomization:             WorkerFactoryOptions.Builder => WorkerFactoryOptions.Builder) {
 
   def withWorkflowHostLocalTaskQueueScheduleToStartTimeout(value: Duration): ZWorkerFactoryOptions =
-    copy(_workflowHostLocalTaskQueueScheduleToStartTimeout = Some(value))
+    copy(workflowHostLocalTaskQueueScheduleToStartTimeout = Some(value))
 
   def withWorkflowCacheSize(value: Int): ZWorkerFactoryOptions =
-    copy(_workflowCacheSize = Some(value))
+    copy(workflowCacheSize = Some(value))
 
   def withMaxWorkflowThreadCount(value: Int): ZWorkerFactoryOptions =
-    copy(_maxWorkflowThreadCount = Some(value))
+    copy(maxWorkflowThreadCount = Some(value))
 
   def withWorkerInterceptors(value: WorkerInterceptor*): ZWorkerFactoryOptions =
-    copy(_workerInterceptors = value.toList)
+    copy(workerInterceptors = value.toList)
 
   def withEnableLoggingInReplay(value: Boolean): ZWorkerFactoryOptions =
-    copy(_enableLoggingInReplay = Some(value))
+    copy(enableLoggingInReplay = Some(value))
 
   def withWorkflowHostLocalPollThreadCount(value: Int): ZWorkerFactoryOptions =
-    copy(_workflowHostLocalPollThreadCount = Some(value))
+    copy(workflowHostLocalPollThreadCount = Some(value))
 
   def toJava: WorkerFactoryOptions = {
     val builder = WorkerFactoryOptions.newBuilder()
@@ -54,26 +46,8 @@ class ZWorkerFactoryOptions private (
     builder.setWorkerInterceptors(workerInterceptors: _*)
     enableLoggingInReplay.foreach(builder.setEnableLoggingInReplay)
     workflowHostLocalPollThreadCount.foreach(builder.setWorkflowHostLocalPollThreadCount)
-    builder.build()
+    javaOptionsCustomization(builder).build()
   }
-
-  private def copy(
-    _workflowHostLocalTaskQueueScheduleToStartTimeout: Option[Duration] =
-      workflowHostLocalTaskQueueScheduleToStartTimeout,
-    _workflowCacheSize:                Option[Int] = workflowCacheSize,
-    _maxWorkflowThreadCount:           Option[Int] = maxWorkflowThreadCount,
-    _workerInterceptors:               List[WorkerInterceptor] = workerInterceptors,
-    _enableLoggingInReplay:            Option[Boolean] = enableLoggingInReplay,
-    _workflowHostLocalPollThreadCount: Option[Int] = workflowHostLocalPollThreadCount
-  ) =
-    new ZWorkerFactoryOptions(
-      _workflowHostLocalTaskQueueScheduleToStartTimeout,
-      _workflowCacheSize,
-      _maxWorkflowThreadCount,
-      _workerInterceptors,
-      _enableLoggingInReplay,
-      _workflowHostLocalPollThreadCount
-    )
 }
 
 object ZWorkerFactoryOptions {
@@ -84,6 +58,7 @@ object ZWorkerFactoryOptions {
     maxWorkflowThreadCount = None,
     workerInterceptors = Nil,
     enableLoggingInReplay = None,
-    workflowHostLocalPollThreadCount = None
+    workflowHostLocalPollThreadCount = None,
+    javaOptionsCustomization = identity
   )
 }

--- a/core/src/main/scala/zio/temporal/worker/ZWorkerFactoryOptions.scala
+++ b/core/src/main/scala/zio/temporal/worker/ZWorkerFactoryOptions.scala
@@ -36,6 +36,17 @@ case class ZWorkerFactoryOptions private[zio] (
   def withWorkflowHostLocalPollThreadCount(value: Int): ZWorkerFactoryOptions =
     copy(workflowHostLocalPollThreadCount = Some(value))
 
+  /** Allows to specify options directly on the java SDK's [[WorkerFactoryOptions]]. Use it in case an appropriate
+    * `withXXX` method is missing
+    *
+    * @note
+    *   the options specified via this method take precedence over those specified via other methods.
+    */
+  def transformJavaOptions(
+    f: WorkerFactoryOptions.Builder => WorkerFactoryOptions.Builder
+  ): ZWorkerFactoryOptions =
+    copy(javaOptionsCustomization = f)
+
   def toJava: WorkerFactoryOptions = {
     val builder = WorkerFactoryOptions.newBuilder()
     workflowHostLocalTaskQueueScheduleToStartTimeout.foreach(timeout =>

--- a/core/src/main/scala/zio/temporal/workflow/ZWorkflowClientOptions.scala
+++ b/core/src/main/scala/zio/temporal/workflow/ZWorkflowClientOptions.scala
@@ -13,45 +13,47 @@ import scala.jdk.CollectionConverters._
   * @see
   *   [[WorkflowClientOptions]]
   */
-class ZWorkflowClientOptions private[zio] (
-  val namespace:            Option[String],
-  val dataConverter:        Option[DataConverter],
-  val interceptors:         List[WorkflowClientInterceptor],
-  val identity:             Option[String],
-  val binaryChecksum:       Option[String],
-  val contextPropagators:   List[ContextPropagator],
-  val queryRejectCondition: Option[QueryRejectCondition]) {
-
-  override def toString: String =
-    s"ZWorkflowClientOptions(" +
-      s"namespace=$namespace, " +
-      s"dataConverter=$dataConverter, " +
-      s"interceptors=$interceptors, " +
-      s"identity=$identity, " +
-      s"binaryChecksum=$binaryChecksum, " +
-      s"contextPropagators=$contextPropagators, " +
-      s"queryRejectCondition=$queryRejectCondition)"
+case class ZWorkflowClientOptions private[zio] (
+  namespace:                            Option[String],
+  dataConverter:                        Option[DataConverter],
+  interceptors:                         List[WorkflowClientInterceptor],
+  identity:                             Option[String],
+  binaryChecksum:                       Option[String],
+  contextPropagators:                   List[ContextPropagator],
+  queryRejectCondition:                 Option[QueryRejectCondition],
+  private val javaOptionsCustomization: WorkflowClientOptions.Builder => WorkflowClientOptions.Builder) {
 
   def withNamespace(value: String): ZWorkflowClientOptions =
-    copy(_namespace = Some(value))
+    copy(namespace = Some(value))
 
   def withDataConverter(value: DataConverter): ZWorkflowClientOptions =
-    copy(_dataConverter = Some(value))
+    copy(dataConverter = Some(value))
 
   def withInterceptors(value: WorkflowClientInterceptor*): ZWorkflowClientOptions =
-    copy(_interceptors = value.toList)
+    copy(interceptors = value.toList)
 
   def withIdentity(value: String): ZWorkflowClientOptions =
-    copy(_identity = Some(value))
+    copy(identity = Some(value))
 
   def withBinaryChecksum(value: String): ZWorkflowClientOptions =
-    copy(_binaryChecksum = Some(value))
+    copy(binaryChecksum = Some(value))
 
   def withContextPropagators(value: ContextPropagator*): ZWorkflowClientOptions =
-    copy(_contextPropagators = value.toList)
+    copy(contextPropagators = value.toList)
 
   def withQueryRejectCondition(value: QueryRejectCondition): ZWorkflowClientOptions =
-    copy(_queryRejectCondition = Some(value))
+    copy(queryRejectCondition = Some(value))
+
+  /** Allows to specify options directly on the java SDK's [[WorkerOptions]]. Use it in case an appropriate `withXXX`
+    * method is missing
+    *
+    * @note
+    *   the options specified via this method take precedence over those specified via other methods.
+    */
+  def transformJavaOptions(
+    f: WorkflowClientOptions.Builder => WorkflowClientOptions.Builder
+  ): ZWorkflowClientOptions =
+    copy(javaOptionsCustomization = f)
 
   def toJava: WorkflowClientOptions = {
     val builder = WorkflowClientOptions.newBuilder()
@@ -64,27 +66,8 @@ class ZWorkflowClientOptions private[zio] (
     builder.setContextPropagators(contextPropagators.asJava)
     queryRejectCondition.foreach(builder.setQueryRejectCondition)
 
-    builder.build()
+    javaOptionsCustomization(builder).build()
   }
-
-  private def copy(
-    _namespace:            Option[String] = namespace,
-    _dataConverter:        Option[DataConverter] = dataConverter,
-    _interceptors:         List[WorkflowClientInterceptor] = interceptors,
-    _identity:             Option[String] = identity,
-    _binaryChecksum:       Option[String] = binaryChecksum,
-    _contextPropagators:   List[ContextPropagator] = contextPropagators,
-    _queryRejectCondition: Option[QueryRejectCondition] = queryRejectCondition
-  ): ZWorkflowClientOptions =
-    new ZWorkflowClientOptions(
-      _namespace,
-      _dataConverter,
-      _interceptors,
-      _identity,
-      _binaryChecksum,
-      _contextPropagators,
-      _queryRejectCondition
-    )
 }
 
 object ZWorkflowClientOptions {
@@ -96,6 +79,7 @@ object ZWorkflowClientOptions {
     identity = None,
     binaryChecksum = None,
     contextPropagators = Nil,
-    queryRejectCondition = None
+    queryRejectCondition = None,
+    javaOptionsCustomization = identity
   )
 }

--- a/core/src/main/scala/zio/temporal/workflow/ZWorkflowClientOptions.scala
+++ b/core/src/main/scala/zio/temporal/workflow/ZWorkflowClientOptions.scala
@@ -44,8 +44,8 @@ case class ZWorkflowClientOptions private[zio] (
   def withQueryRejectCondition(value: QueryRejectCondition): ZWorkflowClientOptions =
     copy(queryRejectCondition = Some(value))
 
-  /** Allows to specify options directly on the java SDK's [[WorkerOptions]]. Use it in case an appropriate `withXXX`
-    * method is missing
+  /** Allows to specify options directly on the java SDK's [[WorkflowClientOptions]]. Use it in case an appropriate
+    * `withXXX` method is missing
     *
     * @note
     *   the options specified via this method take precedence over those specified via other methods.

--- a/core/src/main/scala/zio/temporal/workflow/ZWorkflowOptions.scala
+++ b/core/src/main/scala/zio/temporal/workflow/ZWorkflowOptions.scala
@@ -48,7 +48,7 @@ case class ZWorkflowOptions private[zio] (
   def withContextPropagators(values: ContextPropagator*): ZWorkflowOptions =
     copy(contextPropagators = values.toList)
 
-  /** Allows to specify options directly on the java SDK's [[WorkerOptions]]. Use it in case an appropriate `withXXX`
+  /** Allows to specify options directly on the java SDK's [[WorkflowOptions]]. Use it in case an appropriate `withXXX`
     * method is missing
     *
     * @note

--- a/core/src/main/scala/zio/temporal/workflow/ZWorkflowServiceStubsOptions.scala
+++ b/core/src/main/scala/zio/temporal/workflow/ZWorkflowServiceStubsOptions.scala
@@ -13,21 +13,22 @@ import zio._
   *   [[WorkflowServiceStubsOptions]]
   */
 case class ZWorkflowServiceStubsOptions private[zio] (
-  serverUrl:                       String,
-  channel:                         Option[ManagedChannel],
-  sslContext:                      Option[SslContext],
-  enableHttps:                     Option[Boolean],
-  enableKeepAlive:                 Option[Boolean],
-  keepAliveTime:                   Option[Duration],
-  keepAliveTimeout:                Option[Duration],
-  keepAlivePermitWithoutStream:    Option[Boolean],
-  rpcTimeout:                      Option[Duration],
-  rpcLongPollTimeout:              Option[Duration],
-  rpcQueryTimeout:                 Option[Duration],
-  rpcRetryOptions:                 Option[RpcRetryOptions],
-  connectionBackoffResetFrequency: Option[Duration],
-  grpcReconnectFrequency:          Option[Duration],
-  headers:                         Option[Metadata]) {
+  serverUrl:                            String,
+  channel:                              Option[ManagedChannel],
+  sslContext:                           Option[SslContext],
+  enableHttps:                          Option[Boolean],
+  enableKeepAlive:                      Option[Boolean],
+  keepAliveTime:                        Option[Duration],
+  keepAliveTimeout:                     Option[Duration],
+  keepAlivePermitWithoutStream:         Option[Boolean],
+  rpcTimeout:                           Option[Duration],
+  rpcLongPollTimeout:                   Option[Duration],
+  rpcQueryTimeout:                      Option[Duration],
+  rpcRetryOptions:                      Option[RpcRetryOptions],
+  connectionBackoffResetFrequency:      Option[Duration],
+  grpcReconnectFrequency:               Option[Duration],
+  headers:                              Option[Metadata],
+  private val javaOptionsCustomization: WorkflowServiceStubsOptions.Builder => WorkflowServiceStubsOptions.Builder) {
 
   def withServiceUrl(value: String): ZWorkflowServiceStubsOptions =
     copy(serverUrl = value)
@@ -74,6 +75,17 @@ case class ZWorkflowServiceStubsOptions private[zio] (
   def withHeaders(value: Metadata): ZWorkflowServiceStubsOptions =
     copy(headers = Some(value))
 
+  /** Allows to specify options directly on the java SDK's [[WorkflowServiceStubsOptions]]. Use it in case an
+    * appropriate `withXXX` method is missing
+    *
+    * @note
+    *   the options specified via this method take precedence over those specified via other methods.
+    */
+  def transformJavaOptions(
+    f: WorkflowServiceStubsOptions.Builder => WorkflowServiceStubsOptions.Builder
+  ): ZWorkflowServiceStubsOptions =
+    copy(javaOptionsCustomization = f)
+
   def toJava: WorkflowServiceStubsOptions = {
     val builder = WorkflowServiceStubsOptions.newBuilder()
 
@@ -92,7 +104,7 @@ case class ZWorkflowServiceStubsOptions private[zio] (
     connectionBackoffResetFrequency.foreach(t => builder.setConnectionBackoffResetFrequency(t.asJava))
     grpcReconnectFrequency.foreach(t => builder.setGrpcReconnectFrequency(t.asJava))
     headers.foreach(builder.setHeaders)
-    builder.build()
+    javaOptionsCustomization(builder).build()
   }
 }
 
@@ -113,6 +125,7 @@ object ZWorkflowServiceStubsOptions {
     rpcRetryOptions = None,
     connectionBackoffResetFrequency = None,
     grpcReconnectFrequency = None,
-    headers = None
+    headers = None,
+    javaOptionsCustomization = identity
   )
 }

--- a/core/src/main/scala/zio/temporal/workflow/ZWorkflowStubBuilder.scala
+++ b/core/src/main/scala/zio/temporal/workflow/ZWorkflowStubBuilder.scala
@@ -51,6 +51,16 @@ final class ZWorkflowStubBuilder[A] private[zio] (
   def withRetryOptions(options: ZRetryOptions): ZWorkflowStubBuilder[A] =
     copy(_.setRetryOptions(options.toJava))
 
+  /** Allows to specify options directly on the java SDK's [[WorkflowOptions]]. Use it in case an appropriate `withXXX`
+    * method is missing
+    *
+    * @note
+    *   the options specified via this method take precedence over those specified via other methods.
+    */
+  def transformJavaOptions(
+    f: WorkflowOptions.Builder => WorkflowOptions.Builder
+  ): ZWorkflowStubBuilder[A] = copy(f)
+
   /** Builds typed ZWorkflowStub
     * @return
     *   typed workflow stub


### PR DESCRIPTION
Motivation: it was a bad idea to maintain a self-written version of a `case-class`. 
"Options" classes should still be binary compatible due to the private apply/constructor.

In addition, I've added a `transformJavaOptions` method which allows to transform the corresponding "Options" class that Java's SDK provides.
It will allow users not to struggle due to a missing `withXXX` method (in case `zio-temporal` will have a delay with upgrading to newer java sdk)