### PR TITLE
Allow failing activities with io.temporal.failure.ApplicationFailure via the effect defect channel 

### DIFF
--- a/core/src/main/scala/zio/temporal/activity/ZActivity.scala
+++ b/core/src/main/scala/zio/temporal/activity/ZActivity.scala
@@ -33,7 +33,10 @@ object ZActivity {
       onFailure = cause =>
         zactivityOptions.activityCompletionClient.completeExceptionally(
           taskToken,
-          Activity.wrap(ZActivityFatalError(cause))
+          cause.defects match {
+            case (head: Exception) :: _ => head
+            case _                      => Activity.wrap(ZActivityFatalError(cause))
+          }
         ),
       onSuccess = value =>
         zactivityOptions.activityCompletionClient.complete[A](
@@ -71,7 +74,10 @@ object ZActivity {
       onDie = cause =>
         zactivityOptions.activityCompletionClient.completeExceptionally(
           taskToken,
-          Activity.wrap(ZActivityFatalError(cause))
+          cause.defects match {
+            case (head: Exception) :: _ => head
+            case _                      => Activity.wrap(ZActivityFatalError(cause))
+          }
         ),
       onFailure = error =>
         zactivityOptions.activityCompletionClient.complete[Either[E, A]](


### PR DESCRIPTION
Temporal errors can be marked as retryable or non-retryable. Currently, the only way to return an activity error is via the defects channel, and all defects are wrapped in ZActivityFatalError which is always retryable.
To allow returning non-retryable errors (`io.temporal.failure.ApplicationFailure.newNonRetryableFailure`), we only wrap the cause if there are no defects (which means the effect was interrupted) or if the first defect is not an instance of `Exception`. 