### PR TITLE
Initialize ZWorkflowClientOptions with default data converters

### DIFF
--- a/project/BuildConfig.scala
+++ b/project/BuildConfig.scala
@@ -6,7 +6,8 @@ object BuildConfig extends Dependencies {
 
   val baseLibs = Seq(
     Temporal.self,
-    Zio.self
+    Zio.self,
+    Jackson.scala
   )
 
   val coreLibs = baseLibs ++ Seq(

--- a/testkit/src/main/scala/zio/temporal/testkit/ZTestEnvironmentOptions.scala
+++ b/testkit/src/main/scala/zio/temporal/testkit/ZTestEnvironmentOptions.scala
@@ -63,22 +63,7 @@ object ZTestEnvironmentOptions {
 
   val default: ZTestEnvironmentOptions = new ZTestEnvironmentOptions(
     workerFactoryOptions = ZWorkerFactoryOptions.default,
-    workflowClientOptions = ZWorkflowClientOptions.default.withDataConverter(
-      new DefaultDataConverter(
-        // order matters!
-        Seq(
-          new NullPayloadConverter(),
-          new ByteArrayPayloadConverter(),
-          new ProtobufJsonPayloadConverter(),
-          new JacksonJsonPayloadConverter(
-            JsonMapper
-              .builder()
-              .addModule(DefaultScalaModule)
-              .build()
-          )
-        ): _*
-      )
-    ),
+    workflowClientOptions = ZWorkflowClientOptions.default,
     metricsScope = None,
     useExternalService = None,
     target = None,


### PR DESCRIPTION
This PR initializes `ZWorkflowClientOptions` similar to the java-sdk where FastXML have the scala types module allowing serialization of types like `Either`.

Fixes #34 