### PR TITLE
ZIOAspect-based DSL for workers & testkit

### DIFF
--- a/core/src/main/scala/zio/temporal/activity/ZActivityOptions.scala
+++ b/core/src/main/scala/zio/temporal/activity/ZActivityOptions.scala
@@ -6,7 +6,7 @@ import zio.temporal.workflow.ZWorkflowClient
 
 /** Represents options required to run the effects in the activity implementation
   */
-class ZActivityOptions[R](
+class ZActivityOptions[+R](
   val runtime:                  Runtime[R],
   val activityCompletionClient: ActivityCompletionClient)
 

--- a/core/src/main/scala/zio/temporal/worker/ZWorker.scala
+++ b/core/src/main/scala/zio/temporal/worker/ZWorker.scala
@@ -68,6 +68,7 @@ class ZWorker private[zio] (
   }
 }
 
+// TODO: finish the rest of the ZIOAspect's
 object ZWorker {
 
   def addWorkflow[I: IsWorkflow]: ZWorker.AddWorkflowEnvDsl[I] =

--- a/core/src/main/scala/zio/temporal/worker/ZWorker.scala
+++ b/core/src/main/scala/zio/temporal/worker/ZWorker.scala
@@ -5,23 +5,39 @@ import zio.temporal.internal.ClassTagUtils
 import io.temporal.worker.Worker
 import zio.temporal.activity.IsActivity
 import zio.temporal.workflow.{HasPublicNullaryConstructor, IsConcreteClass, IsWorkflow}
-
+import io.temporal.worker.WorkerFactory
 import scala.reflect.ClassTag
 
 /** Hosts activity and workflow implementations. Uses long poll to receive activity and workflow tasks and processes
   * them in a correspondent thread pool.
   */
 class ZWorker private[zio] (
-  private val self:       Worker,
-  private val workflows:  List[Class[_]],
-  private val activities: List[Class[_]]) {
+  val toJava: Worker) {
 
-  override def toString: String = {
-    val workflowsInfo  = workflows.map(_.getName).mkString("[", ", ", "]")
-    val activitiesInfo = activities.map(_.getName).mkString("[", ", ", "]")
+  def taskQueue: String = toJava.getTaskQueue
 
-    s"ZWorker(taskQueue=${self.getTaskQueue}, workflows=$workflowsInfo, activities=$activitiesInfo)"
-  }
+  def isSuspended: UIO[Boolean] = ZIO.succeed(toJava.isSuspended)
+
+  def suspendPolling: UIO[Unit] =
+    ZIO.blocking(
+      ZIO.succeed(
+        toJava.suspendPolling()
+      )
+    )
+
+  def resumePolling: UIO[Unit] =
+    ZIO.blocking(
+      ZIO.succeed(
+        toJava.resumePolling()
+      )
+    )
+
+  override def toString: String =
+    toJava.toString
+      .replace("Worker", "ZWorker")
+      .replace("WorkerOptions", "ZWorkerOptions")
+      .replace("{", "(")
+      .replace("}", ")")
 
   /** Allows to add workflow to this worker
     */
@@ -34,14 +50,123 @@ class ZWorker private[zio] (
     * @see
     *   [[Worker#registerActivitiesImplementations]]
     */
-  def addActivityImplementation[A <: AnyRef: IsActivity](activity: A): ZWorker = {
-    val cls = activity.getClass
-    self.registerActivitiesImplementations(activity)
-    new ZWorker(self, workflows, cls :: activities)
+  def addActivityImplementation[A <: AnyRef: IsActivity](activity: A): UIO[ZWorker] = ZIO.succeed {
+    toJava.registerActivitiesImplementations(activity)
+    this
+  }
+
+  /** Registers activity implementation objects with a worker. An implementation object can implement one or more
+    * activity types.
+    *
+    * @see
+    *   [[Worker#registerActivitiesImplementations]]
+    */
+  def addActivityImplementationService[A <: AnyRef: IsActivity: Tag]: URIO[A, ZWorker] = {
+    ZIO.serviceWithZIO[A] { activity =>
+      addActivityImplementation[A](activity)
+    }
   }
 }
 
 object ZWorker {
+
+  def addWorkflow[I: IsWorkflow]: ZWorker.AddWorkflowEnvDsl[I] =
+    _AddWorkflowEnvDslInstance.asInstanceOf[AddWorkflowEnvDsl[I]]
+
+  def addActivityImplementation[Act <: AnyRef: IsActivity](activity: Act) =
+    new ZIOAspect[Nothing, Any, Nothing, Any, ZWorker, ZWorker] {
+      override def apply[R >: Nothing <: Any, E >: Nothing <: Any, A >: ZWorker <: ZWorker](
+        zio:            ZIO[R, E, A]
+      )(implicit trace: Trace
+      ): ZIO[R, E, A] =
+        zio.flatMap(_.addActivityImplementation[Act](activity))
+    }
+
+  def addActivityImplementationService[Act <: AnyRef: IsActivity: Tag] =
+    new ZIOAspect[Nothing, Act, Nothing, Any, ZWorker, ZWorker] {
+      override def apply[R >: Nothing <: Act, E >: Nothing <: Any, A >: ZWorker <: ZWorker](
+        zio:            ZIO[R, E, A]
+      )(implicit trace: Trace
+      ): ZIO[R, E, A] =
+        zio.flatMap(_.addActivityImplementationService[Act])
+    }
+
+  private val _AddWorkflowEnvDslInstance = new AddWorkflowEnvDsl[Any]()
+  final class AddWorkflowEnvDsl[I] private[zio] (private val `dummy`: Boolean = true) extends AnyVal {
+
+    // it's already been verified above
+    private implicit def dummyIsWorkflow: IsWorkflow[I] = null
+
+    /** Registers workflow implementation classes with a worker. Can be called multiple times to add more types.
+      *
+      * @param ctg
+      *   workflow interface class tag
+      * @see
+      *   [[Worker#registerWorkflowImplementationTypes]]
+      */
+    def fromClass(
+      implicit ctg:                ClassTag[I],
+      isConcreteClass:             IsConcreteClass[I],
+      hasPublicNullaryConstructor: HasPublicNullaryConstructor[I]
+    ): URIO[ZWorker, ZWorker] =
+      ZIO.serviceWithZIO[ZWorker](_.addWorkflow[I].fromClass)
+
+    /** Registers workflow implementation classes with a worker. Can be called multiple times to add more types.
+      *
+      * @param cls
+      *   workflow interface class tag
+      * @see
+      *   [[Worker#registerWorkflowImplementationTypes]]
+      */
+    def fromClass(
+      cls:                         Class[I]
+    )(implicit isConcreteClass:    IsConcreteClass[I],
+      hasPublicNullaryConstructor: HasPublicNullaryConstructor[I]
+    ): URIO[ZWorker, ZWorker] =
+      ZIO.serviceWithZIO[ZWorker](_.addWorkflow[I].fromClass(cls))
+
+    /** Configures a factory to use when an instance of a workflow implementation is created. The only valid use for
+      * this method is unit testing, specifically to instantiate mocks that implement child workflows. An example of
+      * mocking a child workflow:
+      *
+      * @tparam A
+      *   workflow interface implementation
+      * @param f
+      *   should create a workflow implementation
+      * @param ctg
+      *   workflow interface class tag
+      * @see
+      *   [[Worker#addWorkflowImplementationFactory]]
+      */
+    def from[Wf <: I](f: => Wf)(implicit ctg: ClassTag[I]) =
+      new ZIOAspect[Nothing, Any, Nothing, Any, ZWorker, ZWorker] {
+        override def apply[R >: Nothing <: Any, E >: Nothing <: Any, A >: ZWorker <: ZWorker](
+          zio:            ZIO[R, E, A]
+        )(implicit trace: Trace
+        ): ZIO[R, E, A] =
+          zio.flatMap(_.addWorkflow[I].from(f))
+      }
+
+    /** Configures a factory to use when an instance of a workflow implementation is created. The only valid use for
+      * this method is unit testing, specifically to instantiate mocks that implement child workflows. An example of
+      * mocking a child workflow:
+      *
+      * @param cls
+      *   workflow interface class
+      * @param f
+      *   should create a workflow implementation
+      * @see
+      *   [[Worker#addWorkflowImplementationFactory]]
+      */
+    def from(cls: Class[I], f: () => I) =
+      new ZIOAspect[Nothing, Any, Nothing, Any, ZWorker, ZWorker] {
+        override def apply[R >: Nothing <: Any, E >: Nothing <: Any, A >: ZWorker <: ZWorker](
+          zio:            ZIO[R, E, A]
+        )(implicit trace: Trace
+        ): ZIO[R, E, A] =
+          zio.flatMap(_.addWorkflow[I].from(cls, f))
+      }
+  }
 
   final class AddWorkflowDsl[I] private[zio] (private val worker: ZWorker) extends AnyVal {
 
@@ -56,7 +181,7 @@ object ZWorker {
       implicit ctg:                ClassTag[I],
       isConcreteClass:             IsConcreteClass[I],
       hasPublicNullaryConstructor: HasPublicNullaryConstructor[I]
-    ): ZWorker =
+    ): UIO[ZWorker] =
       fromClass(ClassTagUtils.classOf[I])
 
     /** Registers workflow implementation classes with a worker. Can be called multiple times to add more types.
@@ -69,9 +194,11 @@ object ZWorker {
       cls:                         Class[I]
     )(implicit isConcreteClass:    IsConcreteClass[I],
       hasPublicNullaryConstructor: HasPublicNullaryConstructor[I]
-    ): ZWorker = {
-      worker.self.registerWorkflowImplementationTypes(cls)
-      new ZWorker(worker.self, cls :: worker.workflows, worker.activities)
+    ): UIO[ZWorker] = {
+      ZIO.succeed {
+        worker.toJava.registerWorkflowImplementationTypes(cls)
+        worker
+      }
     }
 
     /** Configures a factory to use when an instance of a workflow implementation is created. The only valid use for
@@ -87,7 +214,7 @@ object ZWorker {
       * @see
       *   [[Worker#addWorkflowImplementationFactory]]
       */
-    def from[A <: I](f: => A)(implicit ctg: ClassTag[I]): ZWorker =
+    def from[A <: I](f: => A)(implicit ctg: ClassTag[I]): UIO[ZWorker] =
       from(ClassTagUtils.classOf[I], () => f)
 
     /** Configures a factory to use when an instance of a workflow implementation is created. The only valid use for
@@ -101,9 +228,10 @@ object ZWorker {
       * @see
       *   [[Worker#addWorkflowImplementationFactory]]
       */
-    def from(cls: Class[I], f: () => I): ZWorker = {
-      worker.self.addWorkflowImplementationFactory[I](cls, () => f())
-      new ZWorker(worker.self, cls :: worker.workflows, worker.activities)
-    }
+    def from(cls: Class[I], f: () => I): UIO[ZWorker] =
+      ZIO.succeed {
+        worker.toJava.registerWorkflowImplementationFactory[I](cls, () => f())
+        worker
+      }
   }
 }

--- a/core/src/main/scala/zio/temporal/worker/ZWorker.scala
+++ b/core/src/main/scala/zio/temporal/worker/ZWorker.scala
@@ -68,7 +68,6 @@ class ZWorker private[zio] (
   }
 }
 
-// TODO: finish the rest of the ZIOAspect's
 object ZWorker {
 
   type Add[+LowerR, -UpperR] = ZIOAspect[LowerR, UpperR, Nothing, Any, ZWorker, ZWorker]

--- a/examples/src/main/scala/com/example/payments/ExampleModule.scala
+++ b/examples/src/main/scala/com/example/payments/ExampleModule.scala
@@ -28,13 +28,8 @@ object ExampleModule {
 
   val worker: URLayer[PaymentActivity with ZWorkerFactory, Unit] =
     ZLayer.fromZIO {
-      ZIO.serviceWithZIO[ZWorkerFactory] { workerFactory =>
-        for {
-          worker       <- workerFactory.newWorker("payments")
-          activityImpl <- ZIO.service[PaymentActivity]
-          _ = worker.addActivityImplementation(activityImpl)
-          _ = worker.addWorkflow[PaymentWorkflow].from(new PaymentWorkflowImpl)
-        } yield ()
-      }
-    }
+      ZWorkerFactory.newWorker("payments") @@
+        ZWorker.addActivityImplementationService[PaymentActivity] @@
+        ZWorker.addWorkflow[PaymentWorkflow].from(new PaymentWorkflowImpl)
+    }.unit
 }

--- a/integration-tests/src/test/scala/zio/temporal/WorkflowSpec.scala
+++ b/integration-tests/src/test/scala/zio/temporal/WorkflowSpec.scala
@@ -2,15 +2,11 @@ package zio.temporal
 
 import zio.*
 import zio.temporal.activity.ZActivityOptions
-import zio.temporal.fixture.Done
-import zio.temporal.fixture.SagaWorkflow
-import zio.temporal.fixture.SagaWorkflowImpl
 import zio.temporal.fixture.*
 import zio.temporal.internal.TemporalWorkflowFacade
 import zio.temporal.signal.*
-import zio.temporal.testkit.ZTestEnvironmentOptions
-import zio.temporal.testkit.ZTestWorkflowEnvironment
-import zio.temporal.worker.ZWorkerOptions
+import zio.temporal.testkit.*
+import zio.temporal.worker.*
 import zio.temporal.workflow.*
 import zio.test.*
 import zio.test.TestAspect.*
@@ -24,220 +20,208 @@ object WorkflowSpec extends ZIOSpecDefault {
 
   override def spec = suite("ZWorkflow")(
     test("runs simple workflow") {
-      ZIO.serviceWithZIO[ZTestWorkflowEnvironment[Any]] { testEnv =>
-        val taskQueue = "sample-queue"
-        val sampleIn  = "Fooo"
-        val sampleOut = sampleIn
-        val client    = testEnv.workflowClient
+      val taskQueue = "sample-queue"
+      val sampleIn  = "Fooo"
+      val sampleOut = sampleIn
 
-        testEnv
-          .newWorker(taskQueue, options = ZWorkerOptions.default)
-          .addWorkflow[SampleWorkflowImpl]
-          .fromClass
-
-        for {
-          _ <- testEnv.setup()
-          sampleWorkflow <- client
-                              .newWorkflowStub[SampleWorkflow]
+      for {
+        _ <- ZTestWorkflowEnvironment.newWorker(taskQueue) @@
+               ZWorker.addWorkflow[SampleWorkflowImpl].fromClass
+        _ <- ZTestWorkflowEnvironment.setup()
+        sampleWorkflow <- ZTestWorkflowEnvironment.workflowClientWithZIO(
+                            _.newWorkflowStub[SampleWorkflow]
                               .withTaskQueue(taskQueue)
                               .withWorkflowId(UUID.randomUUID().toString)
                               .withWorkflowRunTimeout(10.second)
                               .build
-          result <- ZWorkflowStub.execute(sampleWorkflow.echo(sampleIn))
-        } yield assertTrue(result == sampleOut)
-      }
+                          )
+        result <- ZWorkflowStub.execute(sampleWorkflow.echo(sampleIn))
+      } yield assertTrue(result == sampleOut)
+
     }.provideEnv,
     test("runs child workflows") {
-      ZIO.serviceWithZIO[ZTestWorkflowEnvironment[Any]] { testEnv =>
-        val taskQueue = "child-queue"
-        val client    = testEnv.workflowClient
+      val taskQueue = "child-queue"
 
-        testEnv
-          .newWorker(taskQueue, options = ZWorkerOptions.default)
-          .addWorkflow[GreetingWorkflowImpl]
-          .fromClass
-          .addWorkflow[GreetingChildImpl]
-          .fromClass
-        for {
-          _ <- testEnv.setup()
-          greetingWorkflow <- client
-                                .newWorkflowStub[GreetingWorkflow]
+      for {
+        _ <- ZTestWorkflowEnvironment.newWorker(taskQueue) @@
+               ZWorker.addWorkflow[GreetingWorkflowImpl].fromClass @@
+               ZWorker.addWorkflow[GreetingChildImpl].fromClass
+        _ <- ZTestWorkflowEnvironment.setup()
+        greetingWorkflow <- ZTestWorkflowEnvironment.workflowClientWithZIO(
+                              _.newWorkflowStub[GreetingWorkflow]
                                 .withTaskQueue(taskQueue)
                                 .withWorkflowId(UUID.randomUUID().toString)
                                 .withWorkflowRunTimeout(10.second)
                                 .build
-          result <- ZWorkflowStub.execute(greetingWorkflow.getGreeting("Vitalii"))
-        } yield assertTrue(result == "Hello Vitalii!")
-      }
+                            )
+        result <- ZWorkflowStub.execute(greetingWorkflow.getGreeting("Vitalii"))
+      } yield assertTrue(result == "Hello Vitalii!")
+
     }.provideEnv,
     test("run workflow with signals") {
-      ZIO
-        .serviceWithZIO[ZTestWorkflowEnvironment[Any]] { testEnv =>
-          val taskQueue = "signal-queue"
-          val client    = testEnv.workflowClient
+      val taskQueue  = "signal-queue"
+      val workflowId = UUID.randomUUID().toString + taskQueue
 
-          testEnv
-            .newWorker(taskQueue, options = ZWorkerOptions.default)
-            .addWorkflow[SignalWorkflowImpl]
-            .fromClass
+      for {
+        _ <- ZTestWorkflowEnvironment.newWorker(taskQueue) @@
+               ZWorker.addWorkflow[SignalWorkflowImpl].fromClass
+        _ <- ZTestWorkflowEnvironment.setup()
+        signalWorkflow <- ZTestWorkflowEnvironment.workflowClientWithZIO(
+                            _.newWorkflowStub[SignalWorkflow]
+                              .withTaskQueue(taskQueue)
+                              .withWorkflowId(workflowId)
+                              .withWorkflowRunTimeout(30.seconds)
+                              .withWorkflowTaskTimeout(30.seconds)
+                              .withWorkflowExecutionTimeout(30.seconds)
+                              .build
+                          )
+        _ <- ZIO.log("Before start")
+        _ <- ZWorkflowStub.start(
+               signalWorkflow.echoServer("ECHO")
+             )
+        _ <- ZIO.log("Started")
+        workflowStub <- ZTestWorkflowEnvironment.workflowClientWithZIO(
+                          _.newWorkflowStubProxy[SignalWorkflow](workflowId)
+                        )
+        _ <- ZIO.log("New stub created!")
+        progress <- ZWorkflowStub.query(
+                      workflowStub.getProgress(default = None)
+                    )
+        _               <- ZIO.log(s"Progress=$progress")
+        progressDefault <- ZWorkflowStub.query(workflowStub.getProgress(default = Some("default")))
+        _               <- ZIO.log(s"Progress_default=$progressDefault")
+        _ <- ZWorkflowStub.signal(
+               workflowStub.echo("Hello!")
+             )
+        progress2 <- ZWorkflowStub
+                       .query(workflowStub.getProgress(default = None))
+                       .repeatWhile(_.isEmpty)
+        _      <- ZIO.log(s"Progress2=$progress2")
+        result <- workflowStub.result[String]
+      } yield {
+        assertTrue(progress.isEmpty) &&
+        assertTrue(progressDefault.contains("default")) &&
+        assertTrue(progress2.contains("Hello!")) &&
+        assertTrue(result == "ECHO Hello!")
+      }
 
-          val workflowId = UUID.randomUUID().toString + taskQueue
-
-          for {
-            _ <- testEnv.setup()
-            signalWorkflow <- client
-                                .newWorkflowStub[SignalWorkflow]
-                                .withTaskQueue(taskQueue)
-                                .withWorkflowId(workflowId)
-                                .withWorkflowRunTimeout(30.seconds)
-                                .withWorkflowTaskTimeout(30.seconds)
-                                .withWorkflowExecutionTimeout(30.seconds)
-                                .build
-            _ <- ZIO.log("Before start")
-            _ <- ZWorkflowStub
-                   .start(signalWorkflow.echoServer("ECHO"))
-            _               <- ZIO.log("Started")
-            workflowStub    <- client.newWorkflowStubProxy[SignalWorkflow](workflowId)
-            _               <- ZIO.log("New stub created!")
-            progress        <- ZWorkflowStub.query(workflowStub.getProgress(default = None))
-            _               <- ZIO.log(s"Progress=$progress")
-            progressDefault <- ZWorkflowStub.query(workflowStub.getProgress(default = Some("default")))
-            _               <- ZIO.log(s"Progress_default=$progressDefault")
-            _ <- ZWorkflowStub.signal(
-                   workflowStub.echo("Hello!")
-                 )
-            progress2 <- ZWorkflowStub
-                           .query(workflowStub.getProgress(default = None))
-                           .repeatWhile(_.isEmpty)
-            _      <- ZIO.log(s"Progress2=$progress2")
-            result <- workflowStub.result[String]
-          } yield assertTrue(progress.isEmpty) &&
-            assertTrue(progressDefault.contains("default")) &&
-            assertTrue(progress2.contains("Hello!")) &&
-            assertTrue(result == "ECHO Hello!")
-        }
     }.provideEnv,
     test("run workflow with ZIO") {
-      ZIO
-        .serviceWithZIO[ZTestWorkflowEnvironment[Any]] { testEnv =>
-          val taskQueue = "zio-queue"
-          val client    = testEnv.workflowClient
-          import testEnv.activityOptions
+      ZTestWorkflowEnvironment.activityOptionsWithZIO[Any] { implicit activityOptions =>
+        val taskQueue  = "zio-queue"
+        val workflowId = UUID.randomUUID().toString + taskQueue
 
-          testEnv
-            .newWorker(taskQueue, options = ZWorkerOptions.default)
-            .addWorkflow[ZioWorkflowImpl]
-            .fromClass
-            .addActivityImplementation(new ZioActivityImpl())
-
-          val workflowId = UUID.randomUUID().toString + taskQueue
-
-          for {
-            _ <- testEnv.setup()
-            zioWorkflow <- client
-                             .newWorkflowStub[ZioWorkflow]
+        for {
+          _ <- ZTestWorkflowEnvironment.newWorker(taskQueue) @@
+                 ZWorker.addWorkflow[ZioWorkflowImpl].fromClass @@
+                 ZWorker.addActivityImplementation(new ZioActivityImpl()(activityOptions))
+          _ <- ZTestWorkflowEnvironment.setup()
+          zioWorkflow <- ZTestWorkflowEnvironment.workflowClientWithZIO(
+                           _.newWorkflowStub[ZioWorkflow]
                              .withTaskQueue(taskQueue)
                              .withWorkflowId(workflowId)
                              .withWorkflowRunTimeout(30.seconds)
                              .withWorkflowTaskTimeout(30.seconds)
                              .withWorkflowExecutionTimeout(30.seconds)
                              .build
-            _ <- ZWorkflowStub
-                   .start(zioWorkflow.echo("HELLO THERE"))
-            workflowStub <- client.newWorkflowStubProxy[ZioWorkflow](workflowId)
-            _ <- ZWorkflowStub.signal(
-                   workflowStub.complete()
-                 )
-            result <- workflowStub.result[String]
-          } yield assertTrue(result == "Echoed HELLO THERE")
-        }
+                         )
+          _ <- ZWorkflowStub.start(
+                 zioWorkflow.echo("HELLO THERE")
+               )
+          workflowStub <- ZTestWorkflowEnvironment.workflowClientWithZIO(
+                            _.newWorkflowStubProxy[ZioWorkflow](workflowId)
+                          )
+          _ <- ZWorkflowStub.signal(
+                 workflowStub.complete()
+               )
+          result <- workflowStub.result[String]
+        } yield assertTrue(result == "Echoed HELLO THERE")
+      }
+
     }.provideEnv,
     test("run workflow with signal and start") {
-      ZIO.serviceWithZIO[ZTestWorkflowEnvironment[Any]] { testEnv =>
-        val taskQueue = "signal-with-start-queue"
-        val client    = testEnv.workflowClient
+      val taskQueue  = "signal-with-start-queue"
+      val workflowId = UUID.randomUUID().toString
 
-        testEnv
-          .newWorker(taskQueue, options = ZWorkerOptions.default)
-          .addWorkflow[SignalWithStartWorkflowImpl]
-          .fromClass
-
-        val workflowId = UUID.randomUUID().toString
-
-        for {
-          _ <- testEnv.setup()
-          signalWithStartWorkflow <- client
-                                       .newWorkflowStub[SignalWithStartWorkflow]
+      for {
+        _ <- ZTestWorkflowEnvironment.newWorker(taskQueue) @@
+               ZWorker.addWorkflow[SignalWithStartWorkflowImpl].fromClass
+        _ <- ZTestWorkflowEnvironment.setup()
+        signalWithStartWorkflow <- ZTestWorkflowEnvironment.workflowClientWithZIO(
+                                     _.newWorkflowStub[SignalWithStartWorkflow]
                                        .withTaskQueue(taskQueue)
                                        .withWorkflowId(workflowId)
                                        .withWorkflowRunTimeout(10.seconds)
                                        .build
-          _ <- client
-                 .signalWith(
-                   signalWithStartWorkflow.echo("Hello")
-                 )
-                 .start(signalWithStartWorkflow.echoServer())
-          workflowStub <- client.newWorkflowStubProxy[SignalWithStartWorkflow](workflowId)
-          initialSnapshot <- ZWorkflowStub.query(
-                               workflowStub.messages
-                             )
-          _ <- ZWorkflowStub.signal(
-                 workflowStub.echo("World!")
+                                   )
+        _ <- ZTestWorkflowEnvironment.workflowClientWithZIO(
+               _ signalWith (
+                 signalWithStartWorkflow.echo("Hello")
+               ) start (
+                 signalWithStartWorkflow.echoServer()
                )
-          secondSnapshot <- ZWorkflowStub.query(
-                              workflowStub.messages
-                            )
-          _ <- ZWorkflowStub.signal(
-                 workflowStub.echo("Again...")
-               )
-          thirdSnapshot <- ZWorkflowStub.query(
+             )
+        workflowStub <- ZTestWorkflowEnvironment.workflowClientWithZIO(
+                          _.newWorkflowStubProxy[SignalWithStartWorkflow](workflowId)
+                        )
+        initialSnapshot <- ZWorkflowStub.query(
                              workflowStub.messages
                            )
-          _ <- ZWorkflowStub.signal(
-                 workflowStub.stop()
-               )
-          result <- workflowStub.result[Int]
-        } yield assertTrue(initialSnapshot == List("Hello")) &&
-          assertTrue(secondSnapshot == List("Hello", "World!")) &&
-          assertTrue(thirdSnapshot == List("Hello", "World!", "Again...")) &&
-          assertTrue(result == 3)
+        _ <- ZWorkflowStub.signal(
+               workflowStub.echo("World!")
+             )
+        secondSnapshot <- ZWorkflowStub.query(
+                            workflowStub.messages
+                          )
+        _ <- ZWorkflowStub.signal(
+               workflowStub.echo("Again...")
+             )
+        thirdSnapshot <- ZWorkflowStub.query(
+                           workflowStub.messages
+                         )
+        _ <- ZWorkflowStub.signal(
+               workflowStub.stop()
+             )
+        result <- workflowStub.result[Int]
+      } yield {
+        assertTrue(initialSnapshot == List("Hello")) &&
+        assertTrue(secondSnapshot == List("Hello", "World!")) &&
+        assertTrue(thirdSnapshot == List("Hello", "World!", "Again...")) &&
+        assertTrue(result == 3)
       }
+
     }.provideEnv @@ TestAspect.flaky,
     test("run workflow with successful sagas") {
-      ZIO.serviceWithZIO[ZTestWorkflowEnvironment[Any]] { testEnv =>
-        val taskQueue = "saga-queue"
-        val client    = testEnv.workflowClient
-        import testEnv.activityOptions
-
-        val successFunc = (_: String, _: BigDecimal) => ZIO.succeed(Done())
-
+      ZTestWorkflowEnvironment.activityOptionsWithZIO[Any] { implicit activityOptions =>
+        val taskQueue      = "saga-queue"
+        val successFunc    = (_: String, _: BigDecimal) => ZIO.succeed(Done())
         val expectedResult = BigDecimal(5.0)
-
-        testEnv
-          .newWorker(taskQueue, options = ZWorkerOptions.default)
-          .addWorkflow[SagaWorkflowImpl]
-          .fromClass
-          .addActivityImplementation(new TransferActivityImpl(successFunc, successFunc))
-
-        val workflowId = UUID.randomUUID().toString
+        val workflowId     = UUID.randomUUID().toString
 
         for {
-          _ <- testEnv.setup()
-          signalWorkflow <- client
-                              .newWorkflowStub[SagaWorkflow]
-                              .withTaskQueue(taskQueue)
-                              .withWorkflowId(workflowId)
-                              .withWorkflowRunTimeout(10.seconds)
-                              .build
-          result <- ZWorkflowStub.execute(signalWorkflow.transfer(TransferCommand("from", "to", expectedResult)))
-        } yield assertTrue(result == expectedResult)
+          _ <- ZTestWorkflowEnvironment.newWorker(taskQueue) @@
+                 ZWorker.addWorkflow[SagaWorkflowImpl].fromClass @@
+                 ZWorker.addActivityImplementation(new TransferActivityImpl(successFunc, successFunc))
+          _ <- ZTestWorkflowEnvironment.setup()
+          signalWorkflow <- ZTestWorkflowEnvironment.workflowClientWithZIO(
+                              _.newWorkflowStub[SagaWorkflow]
+                                .withTaskQueue(taskQueue)
+                                .withWorkflowId(workflowId)
+                                .withWorkflowRunTimeout(10.seconds)
+                                .build
+                            )
+          result <- ZWorkflowStub.execute(
+                      signalWorkflow.transfer(TransferCommand("from", "to", expectedResult))
+                    )
+        } yield {
+          assertTrue(result == expectedResult)
+        }
       }
+
     }.provideEnv,
     test("run workflow with saga compensations") {
-      ZIO.serviceWithZIO[ZTestWorkflowEnvironment[Any]] { testEnv =>
+      ZTestWorkflowEnvironment.activityOptionsWithZIO[Any] { implicit activityOptions =>
         val taskQueue = "saga-queue"
-        val client    = testEnv.workflowClient
-        import testEnv.activityOptions
 
         val From = "from"
         val To   = "to"
@@ -253,24 +237,21 @@ object WorkflowSpec extends ZIOSpecDefault {
             ZIO.fail(error)
         }
 
-        val amount = BigDecimal(5.0)
-
-        testEnv
-          .newWorker(taskQueue, options = ZWorkerOptions.default)
-          .addWorkflow[SagaWorkflowImpl]
-          .fromClass
-          .addActivityImplementation(new TransferActivityImpl(depositFunc, withdrawFunc))
-
+        val amount     = BigDecimal(5.0)
         val workflowId = UUID.randomUUID().toString
 
         for {
-          _ <- testEnv.setup()
-          sagaWorkflow <- client
-                            .newWorkflowStub[SagaWorkflow]
-                            .withTaskQueue(taskQueue)
-                            .withWorkflowId(workflowId)
-                            .withWorkflowRunTimeout(10.seconds)
-                            .build
+          _ <- ZTestWorkflowEnvironment.newWorker(taskQueue) @@
+                 ZWorker.addWorkflow[SagaWorkflowImpl].fromClass @@
+                 ZWorker.addActivityImplementation(new TransferActivityImpl(depositFunc, withdrawFunc))
+          _ <- ZTestWorkflowEnvironment.setup()
+          sagaWorkflow <- ZTestWorkflowEnvironment.workflowClientWithZIO(
+                            _.newWorkflowStub[SagaWorkflow]
+                              .withTaskQueue(taskQueue)
+                              .withWorkflowId(workflowId)
+                              .withWorkflowRunTimeout(10.seconds)
+                              .build
+                          )
           result <- ZWorkflowStub
                       .execute(sagaWorkflow.transfer(TransferCommand(From, To, amount)))
                       .either
@@ -283,55 +264,59 @@ object WorkflowSpec extends ZIOSpecDefault {
           assertTrue(compensated.get())
         }
       }
+
     }.provideEnv,
     test("run workflow with promise") {
-      ZIO.serviceWithZIO[ZTestWorkflowEnvironment[Any]] { testEnv =>
-        val taskQueue = "promise-queue"
-        val client    = testEnv.workflowClient
+      val taskQueue = "promise-queue"
 
-        val order = new AtomicReference(ListBuffer.empty[(String, Int)])
-        val fooFunc = (x: Int) => {
-          println(s"foo($x)")
-          order.get += ("foo" -> x)
-          x
-        }
-        val barFunc = (x: Int) => {
-          println(s"bar($x)")
-          order.get += ("bar" -> x)
-          x
-        }
+      val order = new AtomicReference(ListBuffer.empty[(String, Int)])
+      val fooFunc = (x: Int) => {
+        println(s"foo($x)")
+        order.get += ("foo" -> x)
+        x
+      }
+      val barFunc = (x: Int) => {
+        println(s"bar($x)")
+        order.get += ("bar" -> x)
+        x
+      }
 
-        testEnv
-          .newWorker(taskQueue, options = ZWorkerOptions.default)
-          .addWorkflow[PromiseWorkflowImpl]
-          .fromClass
-          .addActivityImplementation(new PromiseActivityImpl(fooFunc, barFunc))
+      val x = 2
+      val y = 3
 
-        val x = 2
-        val y = 3
-
-        val tests = for {
-          workflowId <- ZIO.randomWith(_.nextUUID)
-          promiseWorkflow <- client
-                               .newWorkflowStub[PromiseWorkflow]
+      val tests = for {
+        workflowId <- ZIO.randomWith(_.nextUUID)
+        promiseWorkflow <- ZTestWorkflowEnvironment.workflowClientWithZIO(
+                             _.newWorkflowStub[PromiseWorkflow]
                                .withTaskQueue(taskQueue)
                                .withWorkflowId(workflowId.toString)
                                .withWorkflowRunTimeout(10.seconds)
                                .build
-
-          result <- ZWorkflowStub.execute(promiseWorkflow.fooBar(x, y))
-        } yield assertTrue(result == x + y)
-
-        testEnv.setup() *> tests.repeatN(19).map { res =>
-          val actualResult = order.get.toList
-
-          println(actualResult.toString)
-
-          res &&
-          assertTrue(actualResult.size == 40) &&
-          assertTrue(actualResult != List.fill(20)(List("foo" -> x, "bar" -> y)))
-        }
+                           )
+        result <- ZWorkflowStub.execute(promiseWorkflow.fooBar(x, y))
+      } yield {
+        assertTrue(result == x + y)
       }
+
+      for {
+        _ <- ZTestWorkflowEnvironment.newWorker(taskQueue) @@
+               ZWorker.addWorkflow[PromiseWorkflowImpl].fromClass @@
+               ZWorker.addActivityImplementation(new PromiseActivityImpl(fooFunc, barFunc))
+
+        _ <- ZTestWorkflowEnvironment.setup()
+        assertions <- ZIO
+                        .collectAll((1 to 20).map(_ => tests))
+                        .map { res =>
+                          val actualResult = order.get.toList
+
+                          println(actualResult.toString)
+
+                          TestResult.all(res: _*) &&
+                          assertTrue(actualResult.size == 40) &&
+                          assertTrue(actualResult != List.fill(20)(List("foo" -> x, "bar" -> y)))
+                        }
+      } yield assertions
+
     }.provideEnv @@ TestAspect.flaky
   )
 

--- a/testkit/src/main/scala/zio/temporal/testkit/ZTestWorkflowEnvironment.scala
+++ b/testkit/src/main/scala/zio/temporal/testkit/ZTestWorkflowEnvironment.scala
@@ -30,8 +30,12 @@ class ZTestWorkflowEnvironment[R] private[zio] (val toJava: TestWorkflowEnvironm
     * @param taskQueue
     *   task queue to poll.
     */
-  def newWorker(taskQueue: String, options: ZWorkerOptions = ZWorkerOptions.default) =
-    new ZWorker(toJava.newWorker(taskQueue, options.toJava), workflows = Nil, activities = Nil)
+  def newWorker(taskQueue: String, options: ZWorkerOptions = ZWorkerOptions.default): UIO[ZWorker] =
+    ZIO.blocking(
+      ZIO.succeed(
+        new ZWorker(toJava.newWorker(taskQueue, options.toJava))
+      )
+    )
 
   /** Creates a WorkflowClient that is connected to the in-memory test Temporal service. */
   lazy val workflowClient = new ZWorkflowClient(toJava.getWorkflowClient)


### PR DESCRIPTION
The primary motivation for this change is that building the Worker is a side-effect (mutable state + synchronization under the hood).
Therefore, it must be wrapped into `UIO`.

On the other hand, using `ZIOAspect` for building reduces syntactic noise significantly