### PR TITLE
Stubs scaladoc

### DIFF
--- a/core/src/main/scala-2/zio/temporal/activity/ZActivityExecutionSyntax.scala
+++ b/core/src/main/scala-2/zio/temporal/activity/ZActivityExecutionSyntax.scala
@@ -5,9 +5,46 @@ import zio.temporal.workflow.ZAsync
 import scala.language.experimental.macros
 
 trait ZActivityExecutionSyntax {
+
+  /** Executes the given activity synchronously. Accepts the activity method invocation
+    *
+    * Example:
+    * {{{
+    *   val stub: ZActivityStub.Of[T] = ???
+    *
+    *   val result: R = ZActivityStub.execute(
+    *     stub.someMethod(someArg)
+    *   )
+    * }}}
+    *
+    * @tparam R
+    *   activity result type
+    * @param f
+    *   the activity invocation
+    * @return
+    *   the activity result
+    */
   def execute[R](f: R): R =
     macro ZActivityStubMacro.executeImpl[R]
 
+  /** Executes the given activity asynchronously. Accepts the activity method invocation
+    *
+    * Example:
+    * {{{
+    *   val stub: ZActivityStub.Of[T] = ???
+    *
+    *   val result: ZAsync[R] = ZActivityStub.executeAsync(
+    *     stub.someMethod(someArg)
+    *   )
+    * }}}
+    *
+    * @tparam R
+    *   activity result type
+    * @param f
+    *   the activity execution invocation
+    * @return
+    *   the activity result (async)
+    */
   def executeAsync[R](f: R): ZAsync[R] =
     macro ZActivityStubMacro.executeAsyncImpl[R]
 }

--- a/core/src/main/scala-2/zio/temporal/query/ZWorkflowStubQuerySyntax.scala
+++ b/core/src/main/scala-2/zio/temporal/query/ZWorkflowStubQuerySyntax.scala
@@ -6,6 +6,25 @@ import zio.temporal.internal.ZWorkflowQueryMacro
 import scala.language.experimental.macros
 
 trait ZWorkflowStubQuerySyntax {
+
+  /** Queries the given workflow. Accepts the workflow query method invocation
+    *
+    * Example:
+    * {{{
+    *   val stub: ZWorkflowStub.Of[T] = ???
+    *
+    *   val result: TemporalIO[R] = ZWorkflowStub.query(
+    *     stub.someQuery()
+    *   )
+    * }}}
+    *
+    * @tparam R
+    *   query method result type
+    * @param f
+    *   the query method invocation
+    * @return
+    *   the query method result
+    */
   def query[R](f: R): TemporalIO[R] =
     macro ZWorkflowQueryMacro.newQueryImpl[R]
 }

--- a/core/src/main/scala-2/zio/temporal/signal/ZChildWorkflowStubSignalSyntax.scala
+++ b/core/src/main/scala-2/zio/temporal/signal/ZChildWorkflowStubSignalSyntax.scala
@@ -4,6 +4,21 @@ import zio.temporal.internal.ZChildSignalMacro
 import scala.language.experimental.macros
 
 trait ZChildWorkflowStubSignalSyntax {
+
+  /** Sends a signal to the child workflow. Accepts the signal method invocation
+    *
+    * Example:
+    * {{{
+    *   val stub: ZChildWorkflowStub.Of[T] = ???
+    *
+    *   ZChildWorkflowStub.signal(
+    *     stub.someSignalMethod(someArg)
+    *   )
+    * }}}
+    *
+    * @param f
+    *   the signal method invocation
+    */
   def signal(f: Unit): Unit =
     macro ZChildSignalMacro.signalImpl
 }

--- a/core/src/main/scala-2/zio/temporal/signal/ZExternalWorkflowStubSignalSyntax.scala
+++ b/core/src/main/scala-2/zio/temporal/signal/ZExternalWorkflowStubSignalSyntax.scala
@@ -4,6 +4,21 @@ import zio.temporal.internal.ZExternalSignalMacro
 import scala.language.experimental.macros
 
 trait ZExternalWorkflowStubSignalSyntax {
+
+  /** Sends a signal to an external workflow. Accepts the signal method invocation
+    *
+    * Example:
+    * {{{
+    *   val stub: ZExternalWorkflowStub.Of[T] = ???
+    *
+    *   ZExternalWorkflowStub.signal(
+    *     stub.someSignalMethod(someArg)
+    *   )
+    * }}}
+    *
+    * @param f
+    *   the signal method invocation
+    */
   def signal(f: Unit): Unit =
     macro ZExternalSignalMacro.signalImpl
 }

--- a/core/src/main/scala-2/zio/temporal/signal/ZWorkflowStubSignalSyntax.scala
+++ b/core/src/main/scala-2/zio/temporal/signal/ZWorkflowStubSignalSyntax.scala
@@ -7,6 +7,23 @@ import scala.language.experimental.macros
 import scala.language.implicitConversions
 
 trait ZWorkflowStubSignalSyntax {
+
+  /** Sends a signal to the workflow. Accepts the signal method invocation
+    *
+    * Example:
+    * {{{
+    *   val stub: ZWorkflowStub.Of[T] = ???
+    *
+    *  val signalSent: TemporalIO[Unit] = ZWorkflowStub.signal(
+    *     stub.someSignalMethod(someArg)
+    *   )
+    * }}}
+    *
+    * @param f
+    *   the signal method invocation
+    * @return
+    *   ZIO
+    */
   def signal(f: Unit): TemporalIO[Unit] =
     macro ZSignalMacro.signalImpl
 }
@@ -20,7 +37,7 @@ trait ZWorkflowClientSignalWithStartSyntax {
     * @param signal
     *   signal method call
     * @return
-    *   Workflow execution
+    *   Workflow execution metadata
     */
   def signalWithStart(start: Unit, signal: Unit): TemporalIO[ZWorkflowExecution] =
     macro ZSignalMacro.signalWithStartImpl

--- a/core/src/main/scala-2/zio/temporal/workflow/ZChildWorkflowExecutionSyntax.scala
+++ b/core/src/main/scala-2/zio/temporal/workflow/ZChildWorkflowExecutionSyntax.scala
@@ -4,9 +4,46 @@ import zio.temporal.internal.ZChildWorkflowMacro
 import scala.language.experimental.macros
 
 trait ZChildWorkflowExecutionSyntax {
+
+  /** Executes the given child workflow synchronously. Accepts the workflow method invocation
+    *
+    * Example:
+    * {{{
+    *   val stub: ZChildWorkflowStub.Of[T] = ???
+    *
+    *   val result: R = ZChildWorkflowStub.execute(
+    *     stub.someMethod(someArg)
+    *   )
+    * }}}
+    *
+    * @tparam R
+    *   workflow result type
+    * @param f
+    *   the workflow method invocation
+    * @return
+    *   the workflow result
+    */
   def execute[R](f: R): R =
     macro ZChildWorkflowMacro.executeImpl[R]
 
+  /** Executes the given child workflow asynchronously. Accepts the workflow method invocation
+    *
+    * Example:
+    * {{{
+    *   val stub: ZChildWorkflowStub.Of[T] = ???
+    *
+    *   val result: ZAsync[R] = ZChildWorkflowStub.executeAsync(
+    *     stub.someMethod(someArg)
+    *   )
+    * }}}
+    *
+    * @tparam R
+    *   workflow result type
+    * @param f
+    *   the workflow method invocation
+    * @return
+    *   the workflow result (async)
+    */
   def executeAsync[R](f: R): ZAsync[R] =
     macro ZChildWorkflowMacro.executeAsyncImpl[R]
 }

--- a/core/src/main/scala-2/zio/temporal/workflow/ZWorkflowExecutionSyntax.scala
+++ b/core/src/main/scala-2/zio/temporal/workflow/ZWorkflowExecutionSyntax.scala
@@ -7,12 +7,73 @@ import scala.language.experimental.macros
 import scala.language.implicitConversions
 
 trait ZWorkflowExecutionSyntax {
+
+  /** Starts the given workflow. '''Doesn't wait''' for the workflow to finish. Accepts the workflow method invocation
+    *
+    * Example:
+    * {{{
+    *   val stub: ZWorkflowStub.Of[T] = ???
+    *
+    *   val workflowExecution: TemporalIO[ZWorkflowExecution] =
+    *      ZWorkflowStub.start(
+    *        stub.someMethod(someArg)
+    *      )
+    * }}}
+    *
+    * @tparam A
+    *   workflow result type
+    * @param f
+    *   the workflow method invocation
+    * @return
+    *   the workflow execution metadata
+    */
   def start[A](f: A): TemporalIO[ZWorkflowExecution] =
     macro ZWorkflowMacro.startImpl[A]
 
+  /** Executes the given workflow. '''Waits''' for the workflow to finish. Accepts the workflow method invocation
+    *
+    * Example:
+    * {{{
+    *   val stub: ZWorkflowStub.Of[T] = ???
+    *
+    *   val workflowExecution: TemporalIO[R] =
+    *      ZWorkflowStub.execute(
+    *        stub.someMethod(someArg)
+    *      )
+    * }}}
+    *
+    * @tparam R
+    *   workflow result type
+    * @param f
+    *   the workflow method invocation
+    * @return
+    *   the workflow result
+    */
   def execute[R](f: R): TemporalIO[R] =
     macro ZWorkflowMacro.executeImpl[R]
 
+  /** Executes the given workflow with a given timeout. '''Waits''' for the workflow to finish. Accepts the workflow
+    * method invocation
+    *
+    * Example:
+    * {{{
+    *   val stub: ZWorkflowStub.Of[T] = ???
+    *
+    *   val workflowExecution: TemporalIO[R] =
+    *      ZWorkflowStub.executeWithTimeout(5.seconds)(
+    *        stub.someMethod(someArg)
+    *      )
+    * }}}
+    *
+    * @tparam R
+    *   workflow result type
+    * @param timeout
+    *   the timeout
+    * @param f
+    *   the workflow method invocation
+    * @return
+    *   the workflow result
+    */
   def executeWithTimeout[R](timeout: Duration)(f: R): TemporalIO[R] =
     macro ZWorkflowMacro.executeWithTimeoutImpl[R]
 }

--- a/core/src/main/scala-3/zio/temporal/activity/ZActivityExecutionSyntax.scala
+++ b/core/src/main/scala-3/zio/temporal/activity/ZActivityExecutionSyntax.scala
@@ -6,9 +6,46 @@ import scala.quoted._
 import zio.temporal.workflow.ZAsync
 
 trait ZActivityExecutionSyntax {
+
+  /** Executes the given activity synchronously. Accepts the activity method invocation
+    *
+    * Example:
+    * {{{
+    *   val stub: ZActivityStub.Of[T] = ???
+    *
+    *   val result: R = ZActivityStub.execute(
+    *     stub.someMethod(someArg)
+    *   )
+    * }}}
+    *
+    * @tparam R
+    *   activity result type
+    * @param f
+    *   the activity invocation
+    * @return
+    *   the activity result
+    */
   inline def execute[R](inline f: R)(using javaTypeTag: JavaTypeTag[R]): R =
     ${ ZActivityExecutionSyntax.executeImpl[R]('f, 'javaTypeTag) }
 
+  /** Executes the given activity asynchronously. Accepts the activity method invocation
+    *
+    * Example:
+    * {{{
+    *   val stub: ZActivityStub.Of[T] = ???
+    *
+    *   val result: ZAsync[R] = ZActivityStub.executeAsync(
+    *     stub.someMethod(someArg)
+    *   )
+    * }}}
+    *
+    * @tparam R
+    *   activity result type
+    * @param f
+    *   the activity invocation
+    * @return
+    *   the activity result (async)
+    */
   inline def executeAsync[R](inline f: R)(using javaTypeTag: JavaTypeTag[R]): ZAsync[R] =
     ${ ZActivityExecutionSyntax.executeAsyncImpl[R]('f, 'javaTypeTag) }
 }

--- a/core/src/main/scala-3/zio/temporal/query/ZWorkflowStubQuerySyntax.scala
+++ b/core/src/main/scala-3/zio/temporal/query/ZWorkflowStubQuerySyntax.scala
@@ -6,6 +6,25 @@ import zio.temporal.workflow.ZWorkflowStub
 import scala.quoted._
 
 trait ZWorkflowStubQuerySyntax {
+
+  /** Queries the given workflow. Accepts the workflow query method invocation
+    *
+    * Example:
+    * {{{
+    *   val stub: ZWorkflowStub.Of[T] = ???
+    *
+    *   val result: TemporalIO[R] = ZWorkflowStub.query(
+    *     stub.someQuery()
+    *   )
+    * }}}
+    *
+    * @tparam R
+    *   query method result type
+    * @param f
+    *   the query method invocation
+    * @return
+    *   the query method result
+    */
   inline def query[R](inline f: R)(using javaTypeTag: JavaTypeTag[R]): TemporalIO[R] =
     ${ ZWorkflowStubQuerySyntax.queryImpl[R]('f, 'javaTypeTag) }
 }

--- a/core/src/main/scala-3/zio/temporal/signal/ZChildWorkflowStubSignalSyntax.scala
+++ b/core/src/main/scala-3/zio/temporal/signal/ZChildWorkflowStubSignalSyntax.scala
@@ -5,6 +5,21 @@ import zio.temporal.internal.{InvocationMacroUtils, SharedCompileTimeMessages, T
 import zio.temporal.workflow.ZChildWorkflowStub
 
 trait ZChildWorkflowStubSignalSyntax {
+
+  /** Sends a signal to the child workflow. Accepts the signal method invocation
+    *
+    * Example:
+    * {{{
+    *   val stub: ZChildWorkflowStub.Of[T] = ???
+    *
+    *   ZChildWorkflowStub.signal(
+    *     stub.someSignalMethod(someArg)
+    *   )
+    * }}}
+    *
+    * @param f
+    *   the signal method invocation
+    */
   inline def signal(inline f: Unit): Unit =
     ${ ZChildWorkflowStubSignalSyntax.signalImpl('f) }
 }

--- a/core/src/main/scala-3/zio/temporal/signal/ZExternalWorkflowStubSignalSyntax.scala
+++ b/core/src/main/scala-3/zio/temporal/signal/ZExternalWorkflowStubSignalSyntax.scala
@@ -5,6 +5,21 @@ import zio.temporal.internal.{InvocationMacroUtils, SharedCompileTimeMessages, T
 import zio.temporal.workflow.ZExternalWorkflowStub
 
 trait ZExternalWorkflowStubSignalSyntax {
+
+  /** Sends a signal to an external workflow. Accepts the signal method invocation
+    *
+    * Example:
+    * {{{
+    *   val stub: ZExternalWorkflowStub.Of[T] = ???
+    *
+    *   ZExternalWorkflowStub.signal(
+    *     stub.someSignalMethod(someArg)
+    *   )
+    * }}}
+    *
+    * @param f
+    *   the signal method invocation
+    */
   inline def signal(inline f: Unit): Unit =
     ${ ZExternalWorkflowStubSignalSyntax.signalImpl('f) }
 }

--- a/core/src/main/scala-3/zio/temporal/signal/ZWorkflowStubSignalSyntax.scala
+++ b/core/src/main/scala-3/zio/temporal/signal/ZWorkflowStubSignalSyntax.scala
@@ -13,6 +13,23 @@ import zio.temporal.internal.{
 }
 
 trait ZWorkflowStubSignalSyntax {
+
+  /** Sends a signal to the workflow. Accepts the signal method invocation
+    *
+    * Example:
+    * {{{
+    *   val stub: ZWorkflowStub.Of[T] = ???
+    *
+    *  val signalSent: TemporalIO[Unit] = ZWorkflowStub.signal(
+    *     stub.someSignalMethod(someArg)
+    *   )
+    * }}}
+    *
+    * @param f
+    *   the signal method invocation
+    * @return
+    *   ZIO
+    */
   inline def signal(inline f: Unit): TemporalIO[Unit] =
     ${ ZWorkflowStubSignalSyntax.signalImpl('f) }
 }

--- a/core/src/main/scala-3/zio/temporal/workflow/ZChildWorkflowExecutionSyntax.scala
+++ b/core/src/main/scala-3/zio/temporal/workflow/ZChildWorkflowExecutionSyntax.scala
@@ -6,9 +6,46 @@ import zio.temporal.internal.{InvocationMacroUtils, SharedCompileTimeMessages, T
 import scala.quoted._
 
 trait ZChildWorkflowExecutionSyntax {
+
+  /** Executes the given child workflow synchronously. Accepts the workflow method invocation
+    *
+    * Example:
+    * {{{
+    *   val stub: ZChildWorkflowStub.Of[T] = ???
+    *
+    *   val result: R = ZChildWorkflowStub.execute(
+    *     stub.someMethod(someArg)
+    *   )
+    * }}}
+    *
+    * @tparam R
+    *   workflow result type
+    * @param f
+    *   the workflow method invocation
+    * @return
+    *   the workflow result
+    */
   inline def execute[R](inline f: R)(using javaTypeTag: JavaTypeTag[R]): R =
     ${ ZChildWorkflowExecutionSyntax.executeImpl[R]('f, 'javaTypeTag) }
 
+  /** Executes the given child workflow asynchronously. Accepts the workflow method invocation
+    *
+    * Example:
+    * {{{
+    *   val stub: ZChildWorkflowStub.Of[T] = ???
+    *
+    *   val result: ZAsync[R] = ZChildWorkflowStub.executeAsync(
+    *     stub.someMethod(someArg)
+    *   )
+    * }}}
+    *
+    * @tparam R
+    *   workflow result type
+    * @param f
+    *   the workflow method invocation
+    * @return
+    *   the workflow result (async)
+    */
   inline def executeAsync[R](inline f: R)(using javaTypeTag: JavaTypeTag[R]): ZAsync[R] =
     ${ ZChildWorkflowExecutionSyntax.executeAsyncImpl[R]('f, 'javaTypeTag) }
 }

--- a/core/src/main/scala-3/zio/temporal/workflow/ZWorkflowExecutionSyntax.scala
+++ b/core/src/main/scala-3/zio/temporal/workflow/ZWorkflowExecutionSyntax.scala
@@ -7,12 +7,73 @@ import zio.temporal.internal.{InvocationMacroUtils, SharedCompileTimeMessages, T
 import scala.quoted._
 
 trait ZWorkflowExecutionSyntax {
+
+  /** Starts the given workflow. '''Doesn't wait''' for the workflow to finish. Accepts the workflow method invocation
+    *
+    * Example:
+    * {{{
+    *   val stub: ZWorkflowStub.Of[T] = ???
+    *
+    *   val workflowExecution: TemporalIO[ZWorkflowExecution] =
+    *      ZWorkflowStub.start(
+    *        stub.someMethod(someArg)
+    *      )
+    * }}}
+    *
+    * @tparam A
+    *   workflow result type
+    * @param f
+    *   the workflow method invocation
+    * @return
+    *   the workflow execution metadata
+    */
   inline def start[A](inline f: A): TemporalIO[ZWorkflowExecution] =
     ${ ZWorkflowExecutionSyntax.startImpl[A]('f) }
 
+  /** Executes the given workflow. '''Waits''' for the workflow to finish. Accepts the workflow method invocation
+    *
+    * Example:
+    * {{{
+    *   val stub: ZWorkflowStub.Of[T] = ???
+    *
+    *   val workflowExecution: TemporalIO[R] =
+    *      ZWorkflowStub.execute(
+    *        stub.someMethod(someArg)
+    *      )
+    * }}}
+    *
+    * @tparam R
+    *   workflow result type
+    * @param f
+    *   the workflow method invocation
+    * @return
+    *   the workflow result
+    */
   inline def execute[R](inline f: R)(using javaTypeTag: JavaTypeTag[R]): TemporalIO[R] =
     ${ ZWorkflowExecutionSyntax.executeImpl[R]('f, 'javaTypeTag) }
 
+  /** Executes the given workflow with a given timeout. '''Waits''' for the workflow to finish. Accepts the workflow
+    * method invocation
+    *
+    * Example:
+    * {{{
+    *   val stub: ZWorkflowStub.Of[T] = ???
+    *
+    *   val workflowExecution: TemporalIO[R] =
+    *      ZWorkflowStub.executeWithTimeout(5.seconds)(
+    *        stub.someMethod(someArg)
+    *      )
+    * }}}
+    *
+    * @tparam R
+    *   workflow result type
+    * @param timeout
+    *   the timeout
+    * @param f
+    *   the workflow method invocation
+    * @return
+    *   the workflow result
+    */
   inline def executeWithTimeout[R](
     timeout:           Duration
   )(inline f:          R

--- a/core/src/main/scala/zio/temporal/activity/ZActivityStub.scala
+++ b/core/src/main/scala/zio/temporal/activity/ZActivityStub.scala
@@ -8,6 +8,8 @@ import zio.temporal.workflow.ZAsync
 sealed trait ZActivityStub extends BasicStubOps {
   def toJava: ActivityStub
 
+  /** Returns an untyped version of [[ZActivityStub]]
+    */
   def untyped: ZActivityStub.Untyped
 }
 

--- a/core/src/main/scala/zio/temporal/workflow/ZChildWorkflowStub.scala
+++ b/core/src/main/scala/zio/temporal/workflow/ZChildWorkflowStub.scala
@@ -14,6 +14,8 @@ import zio.temporal.signal.ZChildWorkflowStubSignalSyntax
 sealed trait ZChildWorkflowStub extends BasicStubOps {
   def toJava: ChildWorkflowStub
 
+  /** Returns an untyped version of [[ZChildWorkflowStub]]
+    */
   def untyped: ZChildWorkflowStub.Untyped
 
   /** If workflow completes before this promise is ready then the child might not start at all.
@@ -33,7 +35,6 @@ final class ZChildWorkflowStubImpl @internalApi() (val toJava: ChildWorkflowStub
 object ZChildWorkflowStub
     extends Stubs[ZChildWorkflowStub]
     with ZChildWorkflowExecutionSyntax
-    with ZWorkflowStubQuerySyntax
     with ZChildWorkflowStubSignalSyntax {
 
   /** An untyped version of [[ZChildWorkflowStub]]

--- a/core/src/main/scala/zio/temporal/workflow/ZExternalWorkflowStub.scala
+++ b/core/src/main/scala/zio/temporal/workflow/ZExternalWorkflowStub.scala
@@ -13,6 +13,8 @@ import zio.temporal.signal.ZExternalWorkflowStubSignalSyntax
 sealed trait ZExternalWorkflowStub extends BasicStubOps {
   def toJava: ExternalWorkflowStub
 
+  /** Returns an untyped version of [[ZExternalWorkflowStub]]
+    */
   def untyped: ZExternalWorkflowStub.Untyped
 
   def cancel(): Unit =

--- a/core/src/main/scala/zio/temporal/workflow/ZWorkflowStub.scala
+++ b/core/src/main/scala/zio/temporal/workflow/ZWorkflowStub.scala
@@ -12,6 +12,8 @@ import java.util.concurrent.TimeUnit
 sealed trait ZWorkflowStub extends BasicStubOps with ZWorkflowClientSignalWithStartSyntax {
   def toJava: WorkflowStub
 
+  /** Returns an untyped version of [[ZWorkflowStub]]
+    */
   def untyped: ZWorkflowStub.Untyped
 
   /** Fetches workflow result


### PR DESCRIPTION
# Changes being made
- Added more scaladocs for Stubs (XxStub.execute, XxStub.signal, etc.).
- Removed `ZChildWorkflowStub.query` because it doesn't work (Temporal doesn't support querying child workflows directly)


# Additional context
Nothing