### PR TITLE
TemporalIO aliases TemporalExcetion instead of just WorkflowException

### DIFF
--- a/core/src/main/scala/zio/temporal/internal/TemporalInteraction.scala
+++ b/core/src/main/scala/zio/temporal/internal/TemporalInteraction.scala
@@ -1,10 +1,9 @@
 package zio.temporal.internal
 
-import io.temporal.client.WorkflowException
+import io.temporal.failure.TemporalException
 import zio.ZIO
 import zio.temporal.TemporalIO
 import zio.temporal.internalApi
-
 import java.util.concurrent.CompletableFuture
 import scala.concurrent.TimeoutException
 
@@ -14,13 +13,13 @@ object TemporalInteraction {
   def from[A](thunk: => A): TemporalIO[A] = {
     ZIO
       .attemptBlocking(thunk)
-      .refineToOrDie[WorkflowException]
+      .refineToOrDie[TemporalException]
   }
 
   def fromFuture[A](future: => CompletableFuture[A]): TemporalIO[A] =
     ZIO
       .fromFutureJava(future)
-      .refineToOrDie[WorkflowException]
+      .refineToOrDie[TemporalException]
 
   def fromFutureTimeout[A](future: => CompletableFuture[A]): TemporalIO[Option[A]] =
     ZIO
@@ -29,5 +28,5 @@ object TemporalInteraction {
       .catchSome { case _: TimeoutException =>
         ZIO.none
       }
-      .refineToOrDie[WorkflowException]
+      .refineToOrDie[TemporalException]
 }

--- a/core/src/main/scala/zio/temporal/package.scala
+++ b/core/src/main/scala/zio/temporal/package.scala
@@ -2,7 +2,7 @@ package zio
 
 import io.temporal.activity.ActivityInterface
 import io.temporal.activity.ActivityMethod
-import io.temporal.client.WorkflowException
+import io.temporal.failure.TemporalException
 import io.temporal.workflow.QueryMethod
 import io.temporal.workflow.SignalMethod
 import io.temporal.workflow.WorkflowInterface
@@ -26,7 +26,7 @@ package object temporal {
     * @tparam A
     *   the value type
     */
-  final type TemporalIO[+A] = ZIO[Any, WorkflowException, A]
+  final type TemporalIO[+A] = ZIO[Any, TemporalException, A]
 
   /** Alias for IO representing interaction with temporal server
     *
@@ -36,7 +36,7 @@ package object temporal {
     * @tparam A
     *   the value type
     */
-  final type TemporalRIO[-R, +A] = ZIO[R, WorkflowException, A]
+  final type TemporalRIO[-R, +A] = ZIO[R, TemporalException, A]
 
   /** Retrieves class name of a given type. Useful when specifying 'doNotRetry' errors in retry policies.
     * @see

--- a/examples/src/main/scala/com/example/bookingsaga/TripBookingSaga.scala
+++ b/examples/src/main/scala/com/example/bookingsaga/TripBookingSaga.scala
@@ -6,7 +6,7 @@ import zio.temporal.worker._
 import zio.temporal.activity._
 import zio.temporal.workflow._
 import zio.logging.backend.SLF4J
-import io.temporal.client.WorkflowException
+import io.temporal.failure.TemporalException
 
 object TripBookingSaga extends ZIOAppDefault {
   val TaskQueue = "trip-booking"
@@ -33,7 +33,7 @@ object TripBookingSaga extends ZIOAppDefault {
              .execute(
                trip.bookTrip(name)
              )
-             .catchAll { (e: WorkflowException) =>
+             .catchAll { (e: TemporalException) =>
                ZIO.logInfo(s"Workflow execution failed (as expected): $e")
              }
     } yield ()

--- a/examples/src/main/scala/com/example/monitoring/MonitoringMain.scala
+++ b/examples/src/main/scala/com/example/monitoring/MonitoringMain.scala
@@ -5,7 +5,6 @@ import io.micrometer.registry.otlp.{OtlpConfig, OtlpMeterRegistry}
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.context.propagation.{ContextPropagators, TextMapPropagator}
-import io.temporal.client.WorkflowException
 import io.temporal.common.reporter.MicrometerClientStatsReporter
 import io.temporal.opentracing.{OpenTracingClientInterceptor, OpenTracingOptions, OpenTracingWorkerInterceptor}
 import io.opentelemetry.opentracingshim.OpenTracingShim
@@ -16,6 +15,7 @@ import io.opentelemetry.sdk.trace.`export`.SimpleSpanProcessor
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter
 import io.opentelemetry.extension.trace.propagation.OtTracePropagator
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes
+import io.temporal.failure.TemporalException
 import zio._
 import zio.logging.backend.SLF4J
 import zio.temporal._
@@ -35,7 +35,7 @@ object MonitoringMain extends ZIOAppDefault {
         ZWorker.addWorkflow[SampleWorkflowImpl].fromClass @@
         ZWorker.addActivityImplementationService[SampleActivities]
 
-    def invokeWorkflows(who: String): ZIO[ZWorkflowClient, WorkflowException, Unit] =
+    def invokeWorkflows(who: String): ZIO[ZWorkflowClient, TemporalException, Unit] =
       ZIO.serviceWithZIO[ZWorkflowClient] { client =>
         for {
           workflowId <- Random.nextUUID

--- a/examples/src/main/scala/com/example/payments/service/PaymentService.scala
+++ b/examples/src/main/scala/com/example/payments/service/PaymentService.scala
@@ -104,8 +104,8 @@ class TemporalPaymentService(workflowClient: ZWorkflowClient) extends PaymentSer
     }
 
   private def withErrorHandling[R, A](thunk: TemporalRIO[R, A]): ZIO[R, PaymentError, A] =
-    thunk.mapError { workflowException =>
-      PaymentError(workflowException.toString)
+    thunk.mapError { exception =>
+      PaymentError(exception.toString)
     }
 
   private def updateLogContext(transactionId: UUID): UIO[Unit] =


### PR DESCRIPTION
# Changes being made
Previously, `TemporalIO[A]` was `IO[WorkflowException, A]`. Internal zio-temporal methods were refining any temporal-related interaction so that only subtypes of `WorkflowException` was handled.
Therefore, exceptions like `ScheduleAlreadyRunningException`was defects.

This change makes the error handling correct: `TemporalIO[A]` is now `IO[TemporalException, A]`

# Additional context
Please provide any context of the changes if needed