### PR TITLE
Improve attribute passing API

### DIFF
--- a/core/src/main/scala/zio/temporal/ZSearchAttributes.scala
+++ b/core/src/main/scala/zio/temporal/ZSearchAttributes.scala
@@ -61,3 +61,10 @@ final class ZSearchAttributes private[zio] (val toJava: SearchAttributes) {
       s", valueReflectType=${key.getValueReflectType}" +
       s")"
 }
+
+object ZSearchAttributes {
+
+  def fromJava(attrs: SearchAttributes): ZSearchAttributes =
+    new ZSearchAttributes(attrs)
+
+}

--- a/core/src/main/scala/zio/temporal/workflow/ZChildWorkflowStubBuilder.scala
+++ b/core/src/main/scala/zio/temporal/workflow/ZChildWorkflowStubBuilder.scala
@@ -6,9 +6,11 @@ import io.temporal.workflow.ChildWorkflowCancellationType
 import io.temporal.workflow.ChildWorkflowOptions
 import io.temporal.workflow.Workflow
 import io.temporal.api.enums.v1.ParentClosePolicy
+import io.temporal.common.SearchAttributes
 import zio._
 import zio.temporal.internal.ClassTagUtils
-import zio.temporal.{ZRetryOptions, ZSearchAttribute}
+import zio.temporal.{ZRetryOptions, ZSearchAttribute, ZSearchAttributes}
+
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 
@@ -65,6 +67,9 @@ class ZChildWorkflowStubBuilder[Res] private[zio] (
 
   def withSearchAttributes(attrs: Map[String, ZSearchAttribute]): ZChildWorkflowStubBuilder[Res] =
     copy(_.setTypedSearchAttributes(ZSearchAttribute.toJavaSearchAttributes(attrs)))
+
+  def withSearchAttributes(attrs: ZSearchAttributes): ZChildWorkflowStubBuilder[Res] =
+    copy(_.setTypedSearchAttributes(attrs.toJava))
 
   def withCronSchedule(schedule: String): ZChildWorkflowStubBuilder[Res] =
     copy(_.setCronSchedule(schedule))

--- a/core/src/main/scala/zio/temporal/workflow/ZWorkflow.scala
+++ b/core/src/main/scala/zio/temporal/workflow/ZWorkflow.scala
@@ -285,7 +285,7 @@ object ZWorkflow extends ZWorkflowVersionSpecific {
     *   immutable set of search attributes.
     */
   def typedSearchAttributes: ZSearchAttributes =
-    new ZSearchAttributes(Workflow.getTypedSearchAttributes)
+    ZSearchAttributes.fromJava(Workflow.getTypedSearchAttributes)
 
   /** Adds or updates workflow search attributes.
     *

--- a/core/src/main/scala/zio/temporal/workflow/ZWorkflowStubBuilder.scala
+++ b/core/src/main/scala/zio/temporal/workflow/ZWorkflowStubBuilder.scala
@@ -5,7 +5,8 @@ import io.temporal.client.WorkflowOptions
 import io.temporal.api.enums.v1.WorkflowIdReusePolicy
 import io.temporal.common.context.ContextPropagator
 import zio._
-import zio.temporal.{ZRetryOptions, ZSearchAttribute}
+import zio.temporal.{ZRetryOptions, ZSearchAttribute, ZSearchAttributes}
+
 import scala.reflect.ClassTag
 import scala.jdk.CollectionConverters._
 import zio.temporal.internal.ClassTagUtils
@@ -66,6 +67,9 @@ final class ZWorkflowStubBuilder[Res] private[zio] (
 
   def withSearchAttributes(attrs: Map[String, ZSearchAttribute]): ZWorkflowStubBuilder[Res] =
     copy(_.setTypedSearchAttributes(ZSearchAttribute.toJavaSearchAttributes(attrs)))
+
+  def withSearchAttributes(attrs: ZSearchAttributes): ZWorkflowStubBuilder[Res] =
+    copy(_.setTypedSearchAttributes(attrs.toJava))
 
   def withCronSchedule(schedule: String): ZWorkflowStubBuilder[Res] =
     copy(_.setCronSchedule(schedule))

--- a/core/src/test/scala/zio/temporal/ZSearchAttributesSpec.scala
+++ b/core/src/test/scala/zio/temporal/ZSearchAttributesSpec.scala
@@ -11,7 +11,7 @@ import java.{util => ju}
 class ZSearchAttributesSpec extends AnyWordSpec with Matchers {
   "ZSearchAttributes.get" should {
     "return existing attribute decoded" in {
-      val attrs = new ZSearchAttributes(
+      val attrs = ZSearchAttributes.fromJava(
         SearchAttributes
           .newBuilder()
           .set(SearchAttributeKey.forText("foo"), "bar")


### PR DESCRIPTION
# Changes being made

Add an ability to provide `ZSearchAttributes` while building Workflow and Child Workflow.

# Additional context

/resolve #116