### PR TITLE
Remove log message which skips TestAspect.silentLogging

### DIFF
--- a/core/src/main/scala/zio/temporal/worker/ZWorkerFactory.scala
+++ b/core/src/main/scala/zio/temporal/worker/ZWorkerFactory.scala
@@ -38,8 +38,7 @@ final class ZWorkerFactory private[zio] (val toJava: WorkerFactory) {
     *   [[WorkerFactory#shutdown]]
     */
   def shutdown: UIO[Unit] =
-    ZIO.logInfo("ZWorkerFactory shutdown initiated...") *>
-      ZIO.succeedBlocking(toJava.shutdown())
+    ZIO.succeedBlocking(toJava.shutdown())
 
   /** Initiates an orderly shutdown in which polls are stopped and already received workflow and activity tasks are
     * attempted to be stopped. This implementation cancels tasks via Thread.interrupt(), so any task that fails to
@@ -49,8 +48,7 @@ final class ZWorkerFactory private[zio] (val toJava: WorkerFactory) {
     *   [[WorkerFactory#shutdownNow]]
     */
   def shutdownNow: UIO[Unit] =
-    ZIO.logInfo("ZWorkerFactory shutdownNow initiated...") *>
-      ZIO.succeedBlocking(toJava.shutdownNow())
+    ZIO.succeedBlocking(toJava.shutdownNow())
 
   /** Creates worker that connects to an instance of the Temporal Service. It uses the namespace configured at the
     * Factory level. New workers cannot be created after the start() has been called


### PR DESCRIPTION
# Changes being made
Remove log messages on shutdown which skips `TestAspect.silentLogging`

# Additional context
Fixes #128 