### PR TITLE
handle interruption cause

### DIFF
--- a/core/src/main/scala/zio/temporal/internal/ZioUnsafeFacade.scala
+++ b/core/src/main/scala/zio/temporal/internal/ZioUnsafeFacade.scala
@@ -4,30 +4,29 @@ import zio._
 
 object ZioUnsafeFacade {
 
-  def unsafeRunAsyncZIO[R, E, A](
-    runtime:   Runtime[R],
-    action:    ZIO[R, E, A]
-  )(onDie:     Throwable => Unit,
-    onFailure: E => Unit,
-    onSuccess: A => Unit
-  ): Unit =
+  def unsafeRunAsyncZIO[R, E, A](runtime: Runtime[R],
+                                  action: ZIO[R, E, A]
+                                )(onDie: Throwable => Unit,
+                                  onFailure: E => Unit,
+                                  onSuccess: A => Unit
+                                ): Unit =
     Unsafe.unsafe { implicit unsafe: Unsafe =>
-      // Handle defects to avoid noisy error logs
-      val errorsHandled: ZIO[R, Either[Throwable, E], A] = action
-        .mapError(Right(_))
-        .catchAllDefect(defect => ZIO.fail(Left(defect)))
-
-      val fiber = runtime.unsafe.fork(errorsHandled)
+      val fiber = runtime.unsafe.fork(action)
       fiber.unsafe.addObserver {
         case Exit.Failure(cause) =>
-          cause.failureOption.get match {
-            case Left(defect)   => onDie(defect)
-            case Right(failure) => onFailure(failure)
-          }
-
+          cause.isInterrupted
+          cause.failureOrCause.fold(
+            onFailure,
+            {
+              case Cause.Die(t, _) => onDie(t)
+              case _ => onDie(new InterruptedException())
+            }
+          )
         case Exit.Success(value) => onSuccess(value)
       }
+      runtime.unsafe.fork(fiber.interrupt)
     }
+
 
   def unsafeRunZIO[R, E, A](
     runtime:       Runtime[R],

--- a/core/src/main/scala/zio/temporal/internal/ZioUnsafeFacade.scala
+++ b/core/src/main/scala/zio/temporal/internal/ZioUnsafeFacade.scala
@@ -21,7 +21,6 @@ object ZioUnsafeFacade {
           )
         case Exit.Success(value) => onSuccess(value)
       }
-      runtime.unsafe.fork(fiber.interrupt)
     }
 
   def unsafeRunZIO[R, E, A](

--- a/core/src/main/scala/zio/temporal/internal/ZioUnsafeFacade.scala
+++ b/core/src/main/scala/zio/temporal/internal/ZioUnsafeFacade.scala
@@ -15,7 +15,6 @@ object ZioUnsafeFacade {
       val fiber = runtime.unsafe.fork(action)
       fiber.unsafe.addObserver {
         case Exit.Failure(cause) =>
-          cause.isInterrupted
           cause.failureOrCause.fold(
             onFailure,
             _.find { case Cause.Die(t, _) => t }.map(onDie).getOrElse(onDie(new InterruptedException()))


### PR DESCRIPTION
When an activity is interrupted `cause.failureOption.get` will throw a "NoSuchElementException: None.get", this change fixes it.
It also removes the transformation of the error channel to `Either` which seems redundant

