### PR TITLE
Make ZAsync.as by-name

### DIFF
--- a/core/src/main/scala/zio/temporal/workflow/ZAsync.scala
+++ b/core/src/main/scala/zio/temporal/workflow/ZAsync.scala
@@ -42,7 +42,7 @@ sealed trait ZAsync[+A] { self =>
 
   def map[B](f: A => B): ZAsync[B]
 
-  def as[B](value: B): ZAsync[B] =
+  def as[B](value: => B): ZAsync[B] =
     self.map(_ => value)
 
   def unit: ZAsync[Unit] =


### PR DESCRIPTION
# Changes being made
ZAsync.as now accepts a by-name parameter. It's useful in case a side effect is made in the `as` body

# Additional context
Please provide any context of the changes if needed