### PR TITLE
Fix minor error in documentation wording

### DIFF
--- a/docs/src/main/mdoc/contribution.md
+++ b/docs/src/main/mdoc/contribution.md
@@ -11,7 +11,7 @@
 See the list of issues on GitHub and pick one! Or report your own.
 
 If you are having doubts on why or how something works, don't hesitate to ask a question on Discord or via GitHub.  
-This probably means that the documentation, ScalaDocs or code is unclear and be improved for the benefit of all.  
+This probably means that the documentation, ScalaDocs or code is unclear and could be improved for the benefit of all.  
 
 ## Testing locally
 Tests doesn't require any environment installed, so simply run:


### PR DESCRIPTION
# Changes being made
Minor correction to the wording on the documentation page [_Contribution_](https://zio-temporal.vhonta.dev/docs/contribution)
