### PR TITLE
fix: missing activity type prefix name

### DIFF
--- a/core/src/main/scala/zio/temporal/internal/ClassTagUtils.scala
+++ b/core/src/main/scala/zio/temporal/internal/ClassTagUtils.scala
@@ -1,6 +1,6 @@
 package zio.temporal.internal
 
-import zio.temporal.{activityMethod, workflowMethod}
+import zio.temporal.{activityInterface, activityMethod, workflowMethod}
 
 import scala.reflect.ClassTag
 import org.slf4j.LoggerFactory
@@ -37,6 +37,9 @@ private[zio] object ClassTagUtils {
 
   def getActivityType(cls: Class[_], methodName: String): String = {
     val actMethods = cls.getMethods.filter(_.getName == methodName).toList
+    val activityNamePrefix = Option(cls.getAnnotation(Predef.classOf[activityInterface]))
+      .map(_.namePrefix())
+      .getOrElse("")
 
     if (actMethods.isEmpty) {
       throw new NoActivityMethodException(s"$cls doesn't have an activity method '$methodName'!")
@@ -50,7 +53,7 @@ private[zio] object ClassTagUtils {
       .headOption
       .flatMap(ann => Option(ann.name()))
       .filter(_.nonEmpty)
-      .getOrElse(methodName.capitalize)
+      .getOrElse(activityNamePrefix + methodName.capitalize)
 
     logger.trace(s"Activity interface's $cls method=$methodName has activity name $name")
     name


### PR DESCRIPTION
# Changes being made
Fix missing `namePrefix` specifying through annotation `activityInterface` when getting `ActivityType`. The current implementation use the method name directly.

Running example 17: `PaymentActivity`

Modify the annotation
```scala
@activityInterface(namePrefix = "PaymentActivity")
trait PaymentActivity {
  @throws[BankError]
  def proceed(transaction: ProceedTransactionCommand): TransactionView

  @throws[BankError]
  def verifyConfirmation(command: ConfirmTransactionCommand): Unit

  def cancelTransaction(command: CancelTransactionCommand): Unit
}
```

Got error
```
Caused by: io.temporal.failure.ApplicationFailure: message='Activity Type "CancelTransaction" is not registered with a worker. Known types are: PaymentActivityCancelTransaction, PaymentActivityVerifyConfirmation, PaymentActivityProceed', type='java.lang.IllegalArgumentException', nonRetryable=false
```

# Additional context
This issue blocks activity inheritance implementation, since child Actvitity types share the function name (i.e `execute`, `run`), Temporal does not allow us to register duplicated ActivityType, which uses method name by default. Temporal SDK allows us to add the prefix name through `activityInterface` annotation, however, when executing the activity, `ClassTagUtils` misses this piece, that worker cannot find the `ActivityType`.