### PR TITLE
Optimisation: Prefer `ZIO.fromCompletableFuture` over `ZIO.fromFutureJava` as it doesn't need to use `blocking`

### DIFF
--- a/core/src/main/scala/zio/temporal/internal/TemporalInteraction.scala
+++ b/core/src/main/scala/zio/temporal/internal/TemporalInteraction.scala
@@ -10,23 +10,20 @@ import scala.concurrent.TimeoutException
 @internalApi
 object TemporalInteraction {
 
-  def from[A](thunk: => A): TemporalIO[A] = {
+  def from[A](thunk: => A): TemporalIO[A] =
     ZIO
       .attemptBlocking(thunk)
       .refineToOrDie[TemporalException]
-  }
 
   def fromFuture[A](future: => CompletableFuture[A]): TemporalIO[A] =
     ZIO
-      .fromFutureJava(future)
+      .fromCompletableFuture(future)
       .refineToOrDie[TemporalException]
 
   def fromFutureTimeout[A](future: => CompletableFuture[A]): TemporalIO[Option[A]] =
     ZIO
-      .fromFutureJava(future)
+      .fromCompletableFuture(future)
       .map(Option(_))
-      .catchSome { case _: TimeoutException =>
-        ZIO.none
-      }
+      .catchSome { case _: TimeoutException => ZIO.none }
       .refineToOrDie[TemporalException]
 }


### PR DESCRIPTION
`fromCompletableFuture` code is calling `fromCompletionStage` which code is:
```scala
  def fromCompletionStage[A](thunk: => CompletionStage[A])(implicit trace: Trace): Task[A] =
    ZIO.uninterruptibleMask { restore =>
      ZIO.attempt(thunk).flatMap { cs =>
        ZIO.isFatalWith { isFatal =>
          val cf = cs.toCompletableFuture
          if (cf.isDone) {
            unwrapDone(isFatal)(cf)
          } else {
            val cancel = ZIO.succeed(cf.cancel(false))
            restore {
              ZIO.asyncInterrupt[Any, Throwable, A] { cb =>
                val _ = cs.handle[Unit] { (v: A, t: Throwable) =>
                  val io =
                    if (t eq null) Exit.succeed(v)
                    else catchFromGet(isFatal).applyOrElse(t, (d: Throwable) => ZIO.die(d))
                  cb(io)
                }
                Left(cancel)
              }
            }.onInterrupt(cancel)
          }
        }
      }
    }
```

while `fromFutureJava` code is:
```scala
  /**
   * WARNING: this uses the blocking Future#get, consider using
   * `fromCompletionStage`
   */
  def fromFutureJava[A](thunk: => Future[A])(implicit trace: Trace): Task[A] =
    ZIO.uninterruptibleMask { restore =>
      ZIO.attempt(thunk).flatMap { future =>
        ZIO.isFatalWith { isFatal =>
          if (future.isDone) {
            unwrapDone(isFatal)(future)
          } else {
            restore {
              ZIO.blocking(ZIO.suspend(unwrapDone(isFatal)(future)))
            }.onInterrupt(ZIO.succeed(future.cancel(false)))
          }
        }
      }
    }
```